### PR TITLE
Add affinity-assistant image

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -70,8 +70,9 @@ import (
 var (
 	entrypointImage = flag.String("entrypoint-image", "override-with-entrypoint:latest",
 		"The container image containing our entrypoint binary.")
-	nopImage = flag.String("nop-image", "tianon/true", "The container image used to stop sidecars")
-	gitImage = flag.String("git-image", "override-with-git:latest",
+	nopImage               = flag.String("nop-image", "tianon/true", "The container image used to stop sidecars")
+	affinityAssistantImage = flag.String("affinity-assistant-image", "nginx", "The container image used for the Affinity Assistant")
+	gitImage               = flag.String("git-image", "override-with-git:latest",
 		"The container image containing our Git binary.")
 	credsImage = flag.String("creds-image", "override-with-creds:latest",
 		"The container image for preparing our Build's credentials.")
@@ -91,6 +92,7 @@ var (
 func main() {
 	flag.Parse()
 	images := pipeline.Images{
+		AffinityAssistantImage:   *affinityAssistantImage,
 		EntrypointImage:          *entrypointImage,
 		NopImage:                 *nopImage,
 		GitImage:                 *gitImage,

--- a/config/core/deployments/controlplane.yaml
+++ b/config/core/deployments/controlplane.yaml
@@ -59,6 +59,7 @@ spec:
           "-kubeconfig-writer-image", "ko://github.com/tektoncd/pipeline/cmd/kubeconfigwriter",
           "-creds-image", "ko://github.com/tektoncd/pipeline/cmd/creds-init",
           "-git-image", "ko://github.com/tektoncd/pipeline/cmd/git-init",
+          "-affinity-assistant-image", "nginx",
           "-nop-image", "tianon/true",
           "-shell-image", "busybox",
           "-gsutil-image", "google/cloud-sdk",


### PR DESCRIPTION
When attempting to use a pipeline with PVC workspace, Tekton creates a
StatefulSet called affinity-assistant. Since the image wasn't defined,
it causes it to not be able to create a deployment. The TaskRuns that
are spun up are stuck in pending state as it couldn't be scheduled.
After a while the tasks will timeout and the build will fail.

I've added it with the Tekton default `nginx` but it seems like the affinity assistant just needs a container that runs indefinitely. I tested with `devasu/wait` on the Tekton install but not on mink and it seemed to have went through the tasks.