### PR TITLE
Wait for controlplane pods to be up

### DIFF
--- a/.github/workflows/minkind.yaml
+++ b/.github/workflows/minkind.yaml
@@ -213,6 +213,11 @@ jobs:
         # Build and Publish our test images to the docker daemon.
         [[ ! -f ./test/upload-test-images.sh ]] || ./test/upload-test-images.sh
 
+    - name: Wait for controlplane to be up.
+      run: |
+        # We need the controlplane pods to be up (for webhook)
+        kubectl wait pod --for=condition=Ready -n ${SYSTEM_NAMESPACE}  -l app=controlplane
+
     - name: Install in-memory channel
       run: |
         set -o pipefail


### PR DESCRIPTION
This is needed for Tekton because there are no test images being uploaded (which pads this in other legs), and the IMC creates a configmap, which is intermittently rejected because our webhook isn't up.