### PR TITLE
Make hack/build.sh publish and embed the images.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,7 @@ builds:
   flags:
     - -mod=vendor
   ldflags:
+    # KEEP IN SYNC WITH ./hack/build-flags.sh
     - -X 'github.com/mattmoor/mink/pkg/kontext.BaseImageString=docker.io/mattmoor/kontext-expander:v{{.Version}}'
     - -X 'github.com/mattmoor/mink/pkg/builds/buildpacks.PlatformSetupImageString=docker.io/mattmoor/platform-setup:v{{.Version}}'
     - -X 'github.com/mattmoor/mink/pkg/command.BuildDate={{.Date}}'

--- a/hack/build-flags.sh
+++ b/hack/build-flags.sh
@@ -25,5 +25,13 @@ function build_flags() {
     version="v$(date +%Y%m%d)-local-${commit}"
   fi
 
-  echo "-X '${VERSION_PACKAGE}.BuildDate=${now}' -X ${VERSION_PACKAGE}.Version=${version} -X ${VERSION_PACKAGE}.GitRevision=${rev}"
+  local VERSION_PACKAGE="github.com/mattmoor/mink/pkg/command"
+  local KTX_PKG="github.com/mattmoor/mink/pkg/kontext"
+  local BP_PKG="github.com/mattmoor/mink/pkg/builds/buildpacks"
+
+  echo -n "-X '${VERSION_PACKAGE}.BuildDate=${now}' "
+  echo -n "-X ${VERSION_PACKAGE}.Version=${version} "
+  echo -n "-X ${VERSION_PACKAGE}.GitRevision=${rev} "
+  echo -n "-X ${KTX_PKG}.BaseImageString=$(ko publish --platform=all --tags ${version} -B ./cmd/kontext-expander) "
+  echo -n "-X ${BP_PKG}.PlatformSetupImageString=$(ko publish --platform=all --tags ${version} -B ./cmd/platform-setup) "
 }

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -28,9 +28,6 @@ SOURCE_DIRS="cmd pkg"
 # Directory which should be compiled
 MAIN_SOURCE_DIR="cmd/mink"
 
-# Package which holds the version variables
-VERSION_PACKAGE="github.com/mattmoor/mink/pkg/command"
-
 # =================================================
 
 # Store for later

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -176,10 +176,10 @@ for binary in $(find ./config/ -type f | xargs grep ko:// | sed 's@.*ko://@@g' |
     continue
   fi
   mkdir ./vendor/$binary/kodata
-  pushd ./vendor/$binary/kodata
+  pushd ./vendor/$binary/kodata > /dev/null
   ln -s $(echo vendor/$binary/kodata | sed -E 's@[^/]+@..@g')/.git/HEAD .
   ln -s $(echo vendor/$binary/kodata | sed -E 's@[^/]+@..@g')/.git/refs .
   ln -s $(echo vendor/$binary/kodata | sed -E 's@[^/]+@..@g')/LICENSE .
   ln -s $(echo vendor/$binary/kodata | sed -E 's@[^/]+@..@g')/third_party/VENDOR-LICENSE .
-  popd
+  popd > /dev/null
 done

--- a/pkg/builds/buildpacks/build.go
+++ b/pkg/builds/buildpacks/build.go
@@ -43,7 +43,7 @@ const (
 var (
 	PlatformSetupImageString = "docker.io/mattmoor/platform-setup:latest"
 	// BaseImage is where we publish ./cmd/platform-setup
-	PlatformSetupImage, _ = name.NewTag(PlatformSetupImageString)
+	PlatformSetupImage, _ = name.ParseReference(PlatformSetupImageString)
 )
 
 type Options struct {

--- a/pkg/kontext/bundle.go
+++ b/pkg/kontext/bundle.go
@@ -36,7 +36,7 @@ import (
 var (
 	BaseImageString = "docker.io/mattmoor/kontext-expander:latest"
 	// BaseImage is where we publish ./cmd/kontext-expander
-	BaseImage, _ = name.NewTag(BaseImageString)
+	BaseImage, _ = name.ParseReference(BaseImageString)
 )
 
 func bundle(ctx context.Context, directory string) (v1.Layer, error) {


### PR DESCRIPTION
With this the kontext-expander and platform-setup images will be built and embedded into the CLI, which means that our actions will now appropriately test things end-to-end presubmit.

Fixes: https://github.com/mattmoor/mink/issues/133