### PR TITLE
Remove reliance on creds-init for --as=me

### DIFF
--- a/pkg/command/build.go
+++ b/pkg/command/build.go
@@ -149,7 +149,7 @@ func (opts *BuildOptions) Execute(cmd *cobra.Command, args []string) error {
 			Err: cmd.OutOrStderr(),
 		},
 		Follow: true,
-	}, builds.WithServiceAccount(opts.ServiceAccount, opts.tag))
+	}, builds.WithServiceAccount(opts.ServiceAccount, opts.tag, sourceDigest))
 	if err != nil {
 		return err
 	}

--- a/pkg/command/buildpacks.go
+++ b/pkg/command/buildpacks.go
@@ -160,7 +160,7 @@ func (opts *BuildpackOptions) Execute(cmd *cobra.Command, args []string) error {
 			Err: cmd.OutOrStderr(),
 		},
 		Follow: true,
-	}, builds.WithServiceAccount(opts.ServiceAccount, opts.tag))
+	}, builds.WithServiceAccount(opts.ServiceAccount, opts.tag, sourceDigest))
 	if err != nil {
 		return err
 	}

--- a/pkg/command/resolve.go
+++ b/pkg/command/resolve.go
@@ -368,7 +368,7 @@ func (opts *ResolveOptions) db(ctx context.Context, kontext name.Digest, u *url.
 			Err: buf,
 		},
 		Follow: true,
-	}, builds.WithServiceAccount(opts.ServiceAccount, opts.tag))
+	}, builds.WithServiceAccount(opts.ServiceAccount, opts.tag, kontext))
 	if err != nil {
 		log.Print(buf.String())
 		return name.Digest{}, err
@@ -419,7 +419,7 @@ func (opts *ResolveOptions) bp(ctx context.Context, kontext name.Digest, u *url.
 			Err: buf,
 		},
 		Follow: true,
-	}, builds.WithServiceAccount(opts.ServiceAccount, opts.tag))
+	}, builds.WithServiceAccount(opts.ServiceAccount, opts.tag, kontext))
 	if err != nil {
 		log.Print(buf.String())
 		return name.Digest{}, err
@@ -450,7 +450,7 @@ func (opts *ResolveOptions) ko(ctx context.Context, kontext name.Digest, u *url.
 			Err: buf,
 		},
 		Follow: true,
-	}, builds.WithServiceAccount(opts.ServiceAccount, opts.tag))
+	}, builds.WithServiceAccount(opts.ServiceAccount, opts.tag, kontext))
 	if err != nil {
 		log.Print(buf.String())
 		return name.Digest{}, err


### PR DESCRIPTION
This has been replaced with directly mounting the registry secrets into containers with a DOCKER_CONFIG env var (and overriding that).

This also passes auth for the bundle, which may live on a distinct registry.