### PR TITLE
fix: set the config type

### DIFF
--- a/cmd/mink/main.go
+++ b/cmd/mink/main.go
@@ -96,6 +96,8 @@ func initViperConfig() {
 	// these for things to work properly.
 	viper.AddConfigPath(home)
 	viper.SetConfigName(".mink")
+	viper.SetConfigType("yaml")
+
 
 	filename := ".mink.yaml"
 	if nearest := nearestConfig(filename); nearest != "" {

--- a/cmd/mink/main.go
+++ b/cmd/mink/main.go
@@ -98,7 +98,6 @@ func initViperConfig() {
 	viper.SetConfigName(".mink")
 	viper.SetConfigType("yaml")
 
-
 	filename := ".mink.yaml"
 	if nearest := nearestConfig(filename); nearest != "" {
 		searchpath = append(searchpath, nearest)


### PR DESCRIPTION
so that viper properly parses the `.mink.yaml` file locally

I was struggling to use a local `.mink.yaml` and ended up debugging it; without setting this value it seemed to ignore any local `.mink.yaml` file