### PR TITLE
fix: add support for git clone as a source step

### DIFF
--- a/pkg/builds/dockerfile/build.go
+++ b/pkg/builds/dockerfile/build.go
@@ -43,7 +43,7 @@ type Options struct {
 
 // Build returns a TaskRun suitable for performing a Dockerfile build over the
 // provided kontext and publishing to the target tag.
-func Build(ctx context.Context, kontext name.Reference, target name.Tag, opt Options) *tknv1beta1.TaskRun {
+func Build(ctx context.Context, sourceSteps []tknv1beta1.Step, target name.Tag, opt Options) *tknv1beta1.TaskRun {
 	return &tknv1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "dockerfile-",
@@ -58,13 +58,7 @@ func Build(ctx context.Context, kontext name.Reference, target name.Tag, opt Opt
 					Name: "IMAGE-DIGEST",
 				}},
 
-				Steps: []tknv1beta1.Step{{
-					Container: corev1.Container{
-						Name:       "extract-bundle",
-						Image:      kontext.String(),
-						WorkingDir: "/workspace",
-					},
-				}, {
+				Steps: append(sourceSteps, tknv1beta1.Step{
 					Container: corev1.Container{
 						Name:  "build-and-push",
 						Image: KanikoImage,
@@ -88,7 +82,7 @@ func Build(ctx context.Context, kontext name.Reference, target name.Tag, opt Opt
 							"--cache-ttl=24h",
 						},
 					},
-				}},
+				}),
 			},
 		},
 	}

--- a/pkg/builds/ko/build.go
+++ b/pkg/builds/ko/build.go
@@ -43,7 +43,7 @@ var (
 
 // Build returns a TaskRun suitable for performing a "ko publish" build over the
 // provided kontext and publishing to the target tag.
-func Build(ctx context.Context, kontext name.Reference, target name.Tag, opt Options) *tknv1beta1.TaskRun {
+func Build(ctx context.Context, sourceSteps []tknv1beta1.Step, target name.Tag, opt Options) *tknv1beta1.TaskRun {
 	return &tknv1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "ko-publish-",
@@ -58,13 +58,7 @@ func Build(ctx context.Context, kontext name.Reference, target name.Tag, opt Opt
 					Name: "IMAGE-DIGEST",
 				}},
 
-				Steps: []tknv1beta1.Step{{
-					Container: corev1.Container{
-						Name:       "extract-bundle",
-						Image:      kontext.String(),
-						WorkingDir: "/workspace",
-					},
-				}, {
+				Steps: append(sourceSteps, tknv1beta1.Step{
 					Container: corev1.Container{
 						Name:  "ko-publish",
 						Image: KoImageString,
@@ -103,7 +97,7 @@ func Build(ctx context.Context, kontext name.Reference, target name.Tag, opt Opt
 							},
 						},
 					},
-				}},
+				}),
 			},
 		},
 	}

--- a/pkg/command/buildpacks.go
+++ b/pkg/command/buildpacks.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/mattmoor/mink/pkg/builds"
 	"github.com/mattmoor/mink/pkg/builds/buildpacks"
-	"github.com/mattmoor/mink/pkg/kontext"
+	"github.com/mattmoor/mink/pkg/source"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/tektoncd/cli/pkg/cli"
@@ -137,14 +137,14 @@ func (opts *BuildpackOptions) Execute(cmd *cobra.Command, args []string) error {
 	// Handle ctrl+C
 	ctx := signals.NewContext()
 
-	// Bundle up the source context in an image.
-	sourceDigest, err := kontext.Bundle(ctx, opts.Directory, opts.BundleOptions.tag)
+	// Bundle up the source context in an image or use git clone to get the source.
+	sourceSteps, nameRefs, err := source.CreateSourceSteps(ctx, opts.Directory, opts.BundleOptions.tag, opts.BundleOptions.GitLocation)
 	if err != nil {
 		return err
 	}
 
 	// Create a Build definition for turning the source into an image via CNCF Buildpacks.
-	tr := buildpacks.Build(ctx, sourceDigest, opts.tag, buildpacks.Options{
+	tr := buildpacks.Build(ctx, sourceSteps, opts.tag, buildpacks.Options{
 		Builder:      opts.Builder,
 		OverrideFile: opts.OverrideFile,
 	})
@@ -160,7 +160,7 @@ func (opts *BuildpackOptions) Execute(cmd *cobra.Command, args []string) error {
 			Err: cmd.OutOrStderr(),
 		},
 		Follow: true,
-	}, builds.WithServiceAccount(opts.ServiceAccount, opts.tag, sourceDigest))
+	}, builds.WithServiceAccount(opts.ServiceAccount, nameRefs...))
 	if err != nil {
 		return err
 	}

--- a/pkg/command/bundle.go
+++ b/pkg/command/bundle.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/mattmoor/mink/pkg/kontext"
+	"github.com/mattmoor/mink/pkg/source"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"knative.dev/pkg/apis"
@@ -38,6 +39,9 @@ type BundleOptions struct {
 
 	// Director is the string containing the directory to bundle.
 	Directory string
+
+	// GitLocation the git location used to git clone the source if not using a bundle
+	GitLocation *source.GitLocation
 }
 
 // BundleOptions implements Interface
@@ -47,14 +51,39 @@ var _ Interface = (*BundleOptions)(nil)
 func (opts *BundleOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().String("bundle", "", "Where to publish the bundle.")
 	cmd.Flags().String("directory", ".", "The directory to bundle up.")
+
+	cmd.Flags().String("git-url", "", "The git URL to clone the source from if using git clone rather than a bundle image (e.g. if using mink inside a CI/CD pipeline).")
+	cmd.Flags().String("git-rev", "", "The git revision (branch, tag, SHA) to clone the source from if using git clone rather than a bundle image (e.g. if using mink inside a CI/CD pipeline).")
+	cmd.Flags().Bool("git-verbose", false, "If using git to clone the source enable verbose logging")
 }
 
 // Validate implements Interface
 func (opts *BundleOptions) Validate(cmd *cobra.Command, args []string) error {
 	viper.BindPFlags(cmd.Flags())
+
 	opts.ImageName = viper.GetString("bundle")
 	opts.Directory = viper.GetString("directory")
 
+	gitURL := viper.GetString("git-url")
+	if gitURL != "" {
+		if opts.GitLocation == nil {
+			opts.GitLocation = &source.GitLocation{}
+		}
+		opts.GitLocation.URL = gitURL
+		opts.GitLocation.Revision = viper.GetString("git-rev")
+		opts.GitLocation.Verbose = viper.GetBool("git-verbose")
+
+		// lets create a sample source bundle image tag...
+		var err error
+		opts.tag, err = name.NewTag("gcr.io/sample/source-bundle:latest", name.WeakValidation)
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.GitLocation != nil {
+		return nil
+	}
 	if opts.ImageName == "" {
 		return apis.ErrMissingField("bundle")
 	} else if tag, err := name.NewTag(opts.ImageName, name.WeakValidation); err != nil {

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -1,0 +1,104 @@
+package source
+
+import (
+	"context"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/mattmoor/mink/pkg/kontext"
+	tknv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GitLocation allows cloning from git
+type GitLocation struct {
+	// URL the git repo URL
+	URL string
+
+	// Revision is the git revision to clone
+	Revision string
+
+	// Verbose enable verbose logging for git
+	Verbose bool
+}
+
+var (
+	// based on a simplification of the git clone task from the tekton catalog:
+	// https://github.com/tektoncd/catalog/tree/master/task/git-clone
+	gitCloneImage = "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.18.0"
+
+	gitCloneScript = `#!/bin/sh
+set -eu -o pipefail
+if [[ "$VERBOSE" == "true" ]] ; then
+  set -x
+fi
+/ko-app/git-init \
+  -url $GIT_URL \
+  -revision $GIT_REVISION \
+  -path /workspace \
+  -sslVerify=$GIT_SSL_VERIFY \
+  -submodules=$GIT_SUBMODULES \
+  -depth $GIT_DEPTH
+`
+)
+
+// CreateSourceSteps creates the source step(s) to get the source code from an image or git
+func CreateSourceSteps(ctx context.Context, directory string, tag name.Tag, location *GitLocation) ([]tknv1beta1.Step, []name.Reference, error) {
+	if location == nil {
+		// lets bundle the source into a container image
+		kontext, err := kontext.Bundle(ctx, directory, tag)
+		if err != nil {
+			return nil, nil, err
+		}
+		return []tknv1beta1.Step{{
+			Container: corev1.Container{
+				Name:       "extract-bundle",
+				Image:      kontext.String(),
+				WorkingDir: "/workspace",
+			},
+		}}, []name.Reference{tag, kontext}, nil
+	}
+
+	verbose := ""
+	if location.Verbose {
+		verbose = "true"
+	}
+	// lets git clone instead
+	revision := location.Revision
+	if revision == "" {
+		revision = "HEAD"
+	}
+	return []tknv1beta1.Step{{
+		Container: corev1.Container{
+			Name:       "extract-bundle",
+			Image:      gitCloneImage,
+			WorkingDir: "/",
+			Env: []corev1.EnvVar{
+				{
+					Name:  "GIT_URL",
+					Value: location.URL,
+				},
+				{
+					Name:  "GIT_REVISION",
+					Value: revision,
+				},
+				{
+					Name:  "VERBOSE",
+					Value: verbose,
+				},
+				{
+					Name:  "GIT_SSL_VERIFY",
+					Value: "true",
+				},
+				{
+					Name:  "GIT_SUBMODULES",
+					Value: "false",
+				},
+				{
+					Name:  "GIT_DEPTH",
+					Value: "1",
+				},
+			},
+		},
+		Script: gitCloneScript,
+	}}, []name.Reference{tag}, nil
+}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package source
 
 import (


### PR DESCRIPTION
this change allow `--git-url` and an optional `--git-rev` to be passed to `build` and `resolve` commands so that instead of creating a source image bundle we can run builds from a git clone instead

I initially started this because I hit issues on my GCP cluster with source bundles and wanted to be able to try out mink #277 but on further reflection using git clone will be useful when using mink inside CI/CD pipelines triggered on a particular git revision; where creating a source image bundle is not totally necessary (though its ideal when developing locally on your laptop).

This also gives folks the option when running CI/CD pipelines with mink to use source bundle images or use git clones; there are pros and cons to both approaches and depending on your cloud infrastructure, bills, source code size and network there are trade offs for each.

The git clone step is using the git clone image from tekton + is a simplification of the tekton catalog git clone step