### PR TITLE
Refactor resolve to share build logic.

### DIFF
--- a/pkg/builds/buildpacks/build.go
+++ b/pkg/builds/buildpacks/build.go
@@ -70,9 +70,6 @@ type Options struct {
 	// OverrideFile is the name of the override.toml file (under Path)
 	OverrideFile string
 
-	// Path is the path to an overrides.toml, which augments project.toml
-	Path string
-
 	// Env is additional environment variables to pass to the build.
 	Env []corev1.EnvVar
 }
@@ -114,7 +111,7 @@ func Build(ctx context.Context, kontext name.Reference, target name.Tag, opt Opt
 
 	pfSetupArgs := make([]string, 0, 2*(len(opt.Env)+1))
 	pfSetupArgs = append(pfSetupArgs,
-		"--overrides", filepath.Join(workspaceDirectory, opt.Path, opt.OverrideFile),
+		"--overrides", filepath.Join(workspaceDirectory, opt.OverrideFile),
 	)
 	for _, ev := range opt.Env {
 		pfSetupArgs = append(pfSetupArgs,

--- a/pkg/command/build.go
+++ b/pkg/command/build.go
@@ -17,9 +17,12 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/mattmoor/mink/pkg/builds"
 	"github.com/mattmoor/mink/pkg/builds/dockerfile"
 	"github.com/mattmoor/mink/pkg/kontext"
@@ -138,8 +141,25 @@ func (opts *BuildOptions) Execute(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Run the produced Build definition to completion, streaming logs to stdout, and
+	// returning the digest of the produced image.
+	digest, err := opts.build(ctx, sourceDigest, cmd.OutOrStderr())
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", digest.String())
+	return nil
+}
+
+func (opts *BuildOptions) build(ctx context.Context, sourceDigest name.Digest, w io.Writer) (name.Digest, error) {
+	tag, err := opts.Tag()
+	if err != nil {
+		return name.Digest{}, err
+	}
+
 	// Create a Build definition for turning the source into an image by Dockerfile build.
-	tr := dockerfile.Build(ctx, sourceDigest, opts.tag, dockerfile.Options{
+	tr := dockerfile.Build(ctx, sourceDigest, tag, dockerfile.Options{
 		Dockerfile: opts.Dockerfile,
 		KanikoArgs: opts.KanikoArgs,
 	})
@@ -147,19 +167,13 @@ func (opts *BuildOptions) Execute(cmd *cobra.Command, args []string) error {
 
 	// Run the produced Build definition to completion, streaming logs to stdout, and
 	// returning the digest of the produced image.
-	digest, err := builds.Run(ctx, opts.ImageName, tr, &options.LogOptions{
+	return builds.Run(ctx, tag.String(), tr, &options.LogOptions{
 		Params: &cli.TektonParams{},
 		Stream: &cli.Stream{
 			// Send Out to stderr so we can capture the digest for composition.
-			Out: cmd.OutOrStderr(),
-			Err: cmd.OutOrStderr(),
+			Out: w,
+			Err: w,
 		},
 		Follow: true,
-	}, builds.WithServiceAccount(opts.ServiceAccount, opts.tag, sourceDigest))
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", digest.String())
-	return nil
+	}, builds.WithServiceAccount(opts.ServiceAccount, tag, sourceDigest))
 }

--- a/pkg/command/build.go
+++ b/pkg/command/build.go
@@ -153,7 +153,7 @@ func (opts *BuildOptions) Execute(cmd *cobra.Command, args []string) error {
 }
 
 func (opts *BuildOptions) build(ctx context.Context, sourceDigest name.Digest, w io.Writer) (name.Digest, error) {
-	tag, err := opts.Tag()
+	tag, err := opts.tag()
 	if err != nil {
 		return name.Digest{}, err
 	}

--- a/pkg/command/buildbase.go
+++ b/pkg/command/buildbase.go
@@ -59,7 +59,7 @@ func (opts *BaseBuildOptions) Validate(cmd *cobra.Command, args []string) error 
 	opts.ImageName = viper.GetString("image")
 	if opts.ImageName == "" {
 		return apis.ErrMissingField("image")
-	} else if _, err := opts.Tag(); err != nil {
+	} else if _, err := opts.tag(); err != nil {
 		return apis.ErrInvalidValue(err.Error(), "image")
 	}
 
@@ -71,6 +71,6 @@ func (opts *BaseBuildOptions) Validate(cmd *cobra.Command, args []string) error 
 	return nil
 }
 
-func (opts *BaseBuildOptions) Tag() (name.Tag, error) {
+func (opts *BaseBuildOptions) tag() (name.Tag, error) {
 	return name.NewTag(opts.ImageName, name.WeakValidation)
 }

--- a/pkg/command/buildbase.go
+++ b/pkg/command/buildbase.go
@@ -31,9 +31,6 @@ type BaseBuildOptions struct {
 	// ImageName is the string name of the bundle image to which we should publish things.
 	ImageName string
 
-	// tag is the processed version of ImageName that is populated while validating it.
-	tag name.Tag
-
 	// ServiceAccount is the name of the service account *as* which to run the build.
 	ServiceAccount string
 }
@@ -62,16 +59,18 @@ func (opts *BaseBuildOptions) Validate(cmd *cobra.Command, args []string) error 
 	opts.ImageName = viper.GetString("image")
 	if opts.ImageName == "" {
 		return apis.ErrMissingField("image")
-	} else if tag, err := name.NewTag(opts.ImageName, name.WeakValidation); err != nil {
+	} else if _, err := opts.Tag(); err != nil {
 		return apis.ErrInvalidValue(err.Error(), "image")
-	} else {
-		opts.tag = tag
 	}
 
 	opts.ServiceAccount = viper.GetString("as")
 	if opts.ServiceAccount == "" {
-		return apis.ErrMissingField("image")
+		return apis.ErrMissingField("as")
 	}
 
 	return nil
+}
+
+func (opts *BaseBuildOptions) Tag() (name.Tag, error) {
+	return name.NewTag(opts.ImageName, name.WeakValidation)
 }

--- a/pkg/command/buildpacks.go
+++ b/pkg/command/buildpacks.go
@@ -17,9 +17,12 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/mattmoor/mink/pkg/builds"
 	"github.com/mattmoor/mink/pkg/builds/buildpacks"
 	"github.com/mattmoor/mink/pkg/kontext"
@@ -143,8 +146,23 @@ func (opts *BuildpackOptions) Execute(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	digest, err := opts.build(ctx, sourceDigest, cmd.OutOrStderr())
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", digest.String())
+	return nil
+}
+
+func (opts *BuildpackOptions) build(ctx context.Context, sourceDigest name.Digest, w io.Writer) (name.Digest, error) {
+	tag, err := opts.Tag()
+	if err != nil {
+		return name.Digest{}, err
+	}
+
 	// Create a Build definition for turning the source into an image via CNCF Buildpacks.
-	tr := buildpacks.Build(ctx, sourceDigest, opts.tag, buildpacks.Options{
+	tr := buildpacks.Build(ctx, sourceDigest, tag, buildpacks.Options{
 		Builder:      opts.Builder,
 		OverrideFile: opts.OverrideFile,
 	})
@@ -152,19 +170,13 @@ func (opts *BuildpackOptions) Execute(cmd *cobra.Command, args []string) error {
 
 	// Run the produced Build definition to completion, streaming logs to stdout, and
 	// returning the digest of the produced image.
-	digest, err := builds.Run(ctx, opts.ImageName, tr, &options.LogOptions{
+	return builds.Run(ctx, tag.String(), tr, &options.LogOptions{
 		Params: &cli.TektonParams{},
 		Stream: &cli.Stream{
 			// Send Out to stderr so we can capture the digest for composition.
-			Out: cmd.OutOrStderr(),
-			Err: cmd.OutOrStderr(),
+			Out: w,
+			Err: w,
 		},
 		Follow: true,
-	}, builds.WithServiceAccount(opts.ServiceAccount, opts.tag, sourceDigest))
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", digest.String())
-	return nil
+	}, builds.WithServiceAccount(opts.ServiceAccount, tag, sourceDigest))
 }

--- a/pkg/command/buildpacks.go
+++ b/pkg/command/buildpacks.go
@@ -156,7 +156,7 @@ func (opts *BuildpackOptions) Execute(cmd *cobra.Command, args []string) error {
 }
 
 func (opts *BuildpackOptions) build(ctx context.Context, sourceDigest name.Digest, w io.Writer) (name.Digest, error) {
-	tag, err := opts.Tag()
+	tag, err := opts.tag()
 	if err != nil {
 		return name.Digest{}, err
 	}

--- a/pkg/command/resolve.go
+++ b/pkg/command/resolve.go
@@ -390,7 +390,7 @@ func (opts *ResolveOptions) bp(ctx context.Context, kontext name.Digest, u *url.
 }
 
 func (opts *ResolveOptions) ko(ctx context.Context, kontext name.Digest, u *url.URL) (name.Digest, error) {
-	tag, err := opts.Tag()
+	tag, err := opts.tag()
 	if err != nil {
 		return name.Digest{}, err
 	}


### PR DESCRIPTION
Each build performed by resolve can be formulated as a `mink build/buildpack` command (except ko).  This makes that explicit by having each build function delegate to a shared `build()` method on a one-shot `FooOptions` resource, which represents the would-be invocation.

This is cleanup ahead of some forthcoming logic to address: https://github.com/mattmoor/mink/issues/279