### PR TITLE
Add support for go template-based ImageName.

### DIFF
--- a/.github/workflows/minkind-apply.yaml
+++ b/.github/workflows/minkind-apply.yaml
@@ -107,11 +107,11 @@ jobs:
 
         # Send the resulting image here by default!
         image: |
-          {{ if eq .Scheme "ko"}}
+          {{ if eq .Scheme "ko" }}
             ${KO_DOCKER_REPO}/{{ join "ko-images" .Host .Path }}
-          {{ else if eq .Scheme "dockerfile"}}
+          {{ else if eq .Scheme "buildpack" }}
             ${KO_DOCKER_REPO}/{{ join "buildpack-images" .Host .Path }}
-          {{ else if eq .Scheme "buildpacks"}}
+          {{ else if eq .Scheme "dockerfile" }}
             ${KO_DOCKER_REPO}/{{ join "dockerfile-images" .Host .Path }}
           {{ else }}
             ${KO_DOCKER_REPO}/{{ join .Scheme .Host .Path }}

--- a/.github/workflows/minkind-apply.yaml
+++ b/.github/workflows/minkind-apply.yaml
@@ -108,13 +108,13 @@ jobs:
         # Send the resulting image here by default!
         image: |
           {{ if eq .Scheme "ko" }}
-            ${KO_DOCKER_REPO}/{{ join "ko-images" .Host .Path }}
+            ${KO_DOCKER_REPO}/{{ lower (join "ko-images" .Host .Path) }}
           {{ else if eq .Scheme "buildpack" }}
-            ${KO_DOCKER_REPO}/{{ join "buildpack-images" .Host .Path }}
+            ${KO_DOCKER_REPO}/{{ lower (join "buildpack-images" .Host .Path) }}
           {{ else if eq .Scheme "dockerfile" }}
-            ${KO_DOCKER_REPO}/{{ join "dockerfile-images" .Host .Path }}
+            ${KO_DOCKER_REPO}/{{ lower (join "dockerfile-images" .Host .Path) }}
           {{ else }}
-            ${KO_DOCKER_REPO}/{{ join .Scheme .Host .Path }}
+            BREAK THINGS
           {{ end }}
         EOF
 

--- a/.github/workflows/minkind-apply.yaml
+++ b/.github/workflows/minkind-apply.yaml
@@ -24,11 +24,11 @@ jobs:
         - v1.18.x
         - v1.19.x
 
-        include:	
+        include:
         - k8s-version: v1.17.x
-          selfhost-variant: ko	
+          selfhost-variant: ko
         - k8s-version: v1.18.x
-          selfhost-variant: dockerfile	
+          selfhost-variant: dockerfile
         - k8s-version: v1.19.x
           selfhost-variant: buildpacks
 
@@ -106,7 +106,16 @@ jobs:
         bundle: ${KO_DOCKER_REPO}/bundle:latest
 
         # Send the resulting image here by default!
-        image: ${KO_DOCKER_REPO}/image:latest
+        image: |
+          {{ if eq .Scheme "ko"}}
+            ${KO_DOCKER_REPO}/{{ join "ko-images" .Host .Path }}
+          {{ else if eq .Scheme "dockerfile"}}
+            ${KO_DOCKER_REPO}/{{ join "buildpack-images" .Host .Path }}
+          {{ else if eq .Scheme "buildpacks"}}
+            ${KO_DOCKER_REPO}/{{ join "dockerfile-images" .Host .Path }}
+          {{ else }}
+            ${KO_DOCKER_REPO}/{{ join .Scheme .Host .Path }}
+          {{ end }}
         EOF
 
     # Rebuild a self-hosted mink distributing builds using `ko publish`

--- a/.github/workflows/minkind-cli.yaml
+++ b/.github/workflows/minkind-cli.yaml
@@ -113,11 +113,11 @@ jobs:
 
         # Send the resulting image here by default!
         image: |
-          {{ if eq .Scheme "ko"}}
+          {{ if eq .Scheme "ko" }}
             ${KO_DOCKER_REPO}/{{ join "ko-images" .Host .Path }}
-          {{ else if eq .Scheme "dockerfile"}}
+          {{ else if eq .Scheme "buildpack" }}
             ${KO_DOCKER_REPO}/{{ join "buildpack-images" .Host .Path }}
-          {{ else if eq .Scheme "buildpacks"}}
+          {{ else if eq .Scheme "dockerfile" }}
             ${KO_DOCKER_REPO}/{{ join "dockerfile-images" .Host .Path }}
           {{ else }}
             ${KO_DOCKER_REPO}/{{ join .Scheme .Host .Path }}

--- a/.github/workflows/minkind-cli.yaml
+++ b/.github/workflows/minkind-cli.yaml
@@ -114,13 +114,13 @@ jobs:
         # Send the resulting image here by default!
         image: |
           {{ if eq .Scheme "ko" }}
-            ${KO_DOCKER_REPO}/{{ join "ko-images" .Host .Path }}
+            ${KO_DOCKER_REPO}/{{ lower (join "ko-images" .Host .Path) }}
           {{ else if eq .Scheme "buildpack" }}
-            ${KO_DOCKER_REPO}/{{ join "buildpack-images" .Host .Path }}
+            ${KO_DOCKER_REPO}/{{ lower (join "buildpack-images" .Host .Path) }}
           {{ else if eq .Scheme "dockerfile" }}
-            ${KO_DOCKER_REPO}/{{ join "dockerfile-images" .Host .Path }}
+            ${KO_DOCKER_REPO}/{{ lower (join "dockerfile-images" .Host .Path) }}
           {{ else }}
-            ${KO_DOCKER_REPO}/{{ join .Scheme .Host .Path }}
+            BREAK THINGS
           {{ end }}
         EOF
 

--- a/.github/workflows/minkind-cli.yaml
+++ b/.github/workflows/minkind-cli.yaml
@@ -112,7 +112,16 @@ jobs:
         bundle: ${KO_DOCKER_REPO}/bundle:latest
 
         # Send the resulting image here by default!
-        image: ${KO_DOCKER_REPO}/image:latest
+        image: |
+          {{ if eq .Scheme "ko"}}
+            ${KO_DOCKER_REPO}/{{ join "ko-images" .Host .Path }}
+          {{ else if eq .Scheme "dockerfile"}}
+            ${KO_DOCKER_REPO}/{{ join "buildpack-images" .Host .Path }}
+          {{ else if eq .Scheme "buildpacks"}}
+            ${KO_DOCKER_REPO}/{{ join "dockerfile-images" .Host .Path }}
+          {{ else }}
+            ${KO_DOCKER_REPO}/{{ join .Scheme .Host .Path }}
+          {{ end }}
         EOF
 
     - name: Check out Knative Docs

--- a/CLI.md
+++ b/CLI.md
@@ -85,7 +85,7 @@ with something like:
 bundle: ghcr.io/mattmoor/mink-bundles
 
 # Where to upload built images (if unspecified)
-# This may container Go templates with access to Go's url.URL fields; the URL
+# This may contain Go templates with access to Go's url.URL fields; the URL
 # supplied is the equivalent to what a user would specify with resolve or apply.
 #
 # Warning: The use of go templates may result in invalid URLs for certain types
@@ -106,9 +106,9 @@ bundle: ghcr.io/mattmoor/mink-bundles
 image: |
   {{ if eq .Scheme "ko"}}
     ghcr.io/mattmoor/{{ join "ko-images" .Host .Path }}
-  {{ else if eq .Scheme "dockerfile"}}
+  {{ else if eq .Scheme "buildpack"}}
     ghcr.io/mattmoor/{{ join "buildpack-images" .Host .Path }}
-  {{ else if eq .Scheme "buildpacks"}}
+  {{ else if eq .Scheme "dockerfile"}}
     ghcr.io/mattmoor/{{ join "dockerfile-images" .Host .Path }}
   {{ else }}
     ghcr.io/mattmoor/{{ join .Scheme .Host .Path }}

--- a/CLI.md
+++ b/CLI.md
@@ -104,14 +104,14 @@ bundle: ghcr.io/mattmoor/mink-bundles
 #
 #   To use different schemes for each supported scheme:
 image: |
-  {{ if eq .Scheme "ko"}}
-    ghcr.io/mattmoor/{{ join "ko-images" .Host .Path }}
-  {{ else if eq .Scheme "buildpack"}}
-    ghcr.io/mattmoor/{{ join "buildpack-images" .Host .Path }}
-  {{ else if eq .Scheme "dockerfile"}}
-    ghcr.io/mattmoor/{{ join "dockerfile-images" .Host .Path }}
+  {{ if eq .Scheme "ko" }}
+    ghcr.io/mattmoor/{{ lower (join "ko-images" .Host .Path) }}
+  {{ else if eq .Scheme "buildpack" }}
+    ghcr.io/mattmoor/{{ lower (join "buildpack-images" .Host .Path) }}
+  {{ else if eq .Scheme "dockerfile" }}
+    ghcr.io/mattmoor/{{ lower (join "dockerfile-images" .Host .Path) }}
   {{ else }}
-    ghcr.io/mattmoor/{{ join .Scheme .Host .Path }}
+    ghcr.io/mattmoor/{{ lower (join .Scheme .Host .Path) }}
   {{ end }}
 
 

--- a/pkg/command/build.go
+++ b/pkg/command/build.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
+	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/mattmoor/mink/pkg/builds"
@@ -153,7 +155,12 @@ func (opts *BuildOptions) Execute(cmd *cobra.Command, args []string) error {
 }
 
 func (opts *BuildOptions) build(ctx context.Context, sourceDigest name.Digest, w io.Writer) (name.Digest, error) {
-	tag, err := opts.tag()
+	tag, err := opts.tag(imageNameContext{
+		URL: url.URL{
+			Scheme: "dockerfile",
+			Path:   filepath.Clean(filepath.Dir(opts.Dockerfile)),
+		},
+	})
 	if err != nil {
 		return name.Digest{}, err
 	}

--- a/pkg/command/buildbase.go
+++ b/pkg/command/buildbase.go
@@ -55,7 +55,7 @@ func (opts *BaseBuildOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().String("image", "", "Where to publish the final image.  This can be a go template "+
 		"and has access to the url.URL fields (e.g. Scheme, Host, Path) that would represent this "+
 		"build with the resolve command.  Functions are also provided for: basename, dirname, join, "+
-		"and split.")
+		"lower, and split.")
 	cmd.Flags().String("as", "default",
 		"The name of the ServiceAccount as which to run the build, pass --as=me to "+
 			"temporarily create a new ServiceAccount to push with your local credentials.")
@@ -97,6 +97,7 @@ var imageNameFunctions = template.FuncMap{
 	"dirname":  path.Dir,
 	"join":     path.Join,
 	"split":    strings.Split,
+	"lower":    strings.ToLower,
 }
 
 func (opts *BaseBuildOptions) tag(inc imageNameContext) (name.Tag, error) {

--- a/pkg/command/buildbase.go
+++ b/pkg/command/buildbase.go
@@ -75,7 +75,12 @@ func (opts *BaseBuildOptions) Validate(cmd *cobra.Command, args []string) error 
 		return apis.ErrInvalidValue(err.Error(), "image")
 	} else {
 		opts.tmpl = tmpl
-		if _, err := opts.tag(imageNameContext{}); err != nil {
+		if _, err := opts.tag(imageNameContext{
+			URL: url.URL{
+				// Arbitrary choice, but we should always have at least scheme.
+				Scheme: "dockerfile",
+			},
+		}); err != nil {
 			return apis.ErrInvalidValue(err.Error(), "image")
 		}
 	}

--- a/pkg/command/buildbase.go
+++ b/pkg/command/buildbase.go
@@ -52,7 +52,7 @@ func (opts *BaseBuildOptions) AddFlags(cmd *cobra.Command) {
 	// Add the bundle flags to our surface.
 	opts.BundleOptions.AddFlags(cmd)
 
-	cmd.Flags().String("image", "", "Where to publish the final image.  This can be a go template, "+
+	cmd.Flags().String("image", "", "Where to publish the final image.  This can be a go template "+
 		"and has access to the url.URL fields (e.g. Scheme, Host, Path) that would represent this "+
 		"build with the resolve command.  Functions are also provided for: basename, dirname, join, "+
 		"and split.")

--- a/pkg/command/buildbase.go
+++ b/pkg/command/buildbase.go
@@ -17,6 +17,12 @@ limitations under the License.
 package command
 
 import (
+	"bytes"
+	"net/url"
+	"path"
+	"strings"
+	"text/template"
+
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -33,6 +39,9 @@ type BaseBuildOptions struct {
 
 	// ServiceAccount is the name of the service account *as* which to run the build.
 	ServiceAccount string
+
+	// tmpl is the template used to instantiate image names.
+	tmpl *template.Template
 }
 
 // BaseBuildOptions implements Interface
@@ -43,7 +52,10 @@ func (opts *BaseBuildOptions) AddFlags(cmd *cobra.Command) {
 	// Add the bundle flags to our surface.
 	opts.BundleOptions.AddFlags(cmd)
 
-	cmd.Flags().String("image", "", "Where to publish the final image.")
+	cmd.Flags().String("image", "", "Where to publish the final image.  This can be a go template, "+
+		"and has access to the url.URL fields (e.g. Scheme, Host, Path) that would represent this "+
+		"build with the resolve command.  Functions are also provided for: basename, dirname, join, "+
+		"and split.")
 	cmd.Flags().String("as", "default",
 		"The name of the ServiceAccount as which to run the build, pass --as=me to "+
 			"temporarily create a new ServiceAccount to push with your local credentials.")
@@ -59,8 +71,13 @@ func (opts *BaseBuildOptions) Validate(cmd *cobra.Command, args []string) error 
 	opts.ImageName = viper.GetString("image")
 	if opts.ImageName == "" {
 		return apis.ErrMissingField("image")
-	} else if _, err := opts.tag(); err != nil {
+	} else if tmpl, err := template.New("image").Funcs(imageNameFunctions).Parse(opts.ImageName); err != nil {
 		return apis.ErrInvalidValue(err.Error(), "image")
+	} else {
+		opts.tmpl = tmpl
+		if _, err := opts.tag(imageNameContext{}); err != nil {
+			return apis.ErrInvalidValue(err.Error(), "image")
+		}
 	}
 
 	opts.ServiceAccount = viper.GetString("as")
@@ -71,6 +88,21 @@ func (opts *BaseBuildOptions) Validate(cmd *cobra.Command, args []string) error 
 	return nil
 }
 
-func (opts *BaseBuildOptions) tag() (name.Tag, error) {
-	return name.NewTag(opts.ImageName, name.WeakValidation)
+type imageNameContext struct {
+	url.URL
+}
+
+var imageNameFunctions = template.FuncMap{
+	"basename": path.Base,
+	"dirname":  path.Dir,
+	"join":     path.Join,
+	"split":    strings.Split,
+}
+
+func (opts *BaseBuildOptions) tag(inc imageNameContext) (name.Tag, error) {
+	buf := bytes.NewBuffer(nil)
+	if err := opts.tmpl.Execute(buf, inc); err != nil {
+		return name.Tag{}, err
+	}
+	return name.NewTag(strings.TrimSpace(buf.String()), name.WeakValidation)
 }

--- a/pkg/command/buildpacks.go
+++ b/pkg/command/buildpacks.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
+	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/mattmoor/mink/pkg/builds"
@@ -156,7 +158,12 @@ func (opts *BuildpackOptions) Execute(cmd *cobra.Command, args []string) error {
 }
 
 func (opts *BuildpackOptions) build(ctx context.Context, sourceDigest name.Digest, w io.Writer) (name.Digest, error) {
-	tag, err := opts.tag()
+	tag, err := opts.tag(imageNameContext{
+		URL: url.URL{
+			Scheme: "buildpack",
+			Path:   filepath.Clean(filepath.Dir(opts.OverrideFile)),
+		},
+	})
 	if err != nil {
 		return name.Digest{}, err
 	}

--- a/pkg/command/resolve.go
+++ b/pkg/command/resolve.go
@@ -390,7 +390,9 @@ func (opts *ResolveOptions) bp(ctx context.Context, kontext name.Digest, u *url.
 }
 
 func (opts *ResolveOptions) ko(ctx context.Context, kontext name.Digest, u *url.URL) (name.Digest, error) {
-	tag, err := opts.tag()
+	tag, err := opts.tag(imageNameContext{
+		URL: *u,
+	})
 	if err != nil {
 		return name.Digest{}, err
 	}


### PR DESCRIPTION
With this, folks should be able to preserve the current behavior, but also gain access to rich capabilities that allow them to replicate `ko`s various built-in "namers", but also do even more sophisticated things.

Fixes: https://github.com/mattmoor/mink/issues/279