### PR TITLE
Implement support for `mink run`.

### DIFF
--- a/.github/workflows/minkind-run.yaml
+++ b/.github/workflows/minkind-run.yaml
@@ -1,4 +1,4 @@
-name: MinKinD Bundle E2Es
+name: MinKinD Run E2Es
 
 on:
   pull_request:
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.17.x
+        - v1.19.x
 
     env:
       GOPATH: ${{ github.workspace }}
@@ -85,25 +85,61 @@ jobs:
           {{ end }}
         EOF
 
-    - name: Git bundle mink-apply-nodejs
+    - name: Test mink run task
+      working-directory: ./src/github.com/mattmoor/mink
       run: |
-        BEFORE_DIGEST=$(mink bundle --git-url=https://github.com/mattmoor/mink-apply-nodejs --git-ref=refs/heads/main)
-        echo BEFORE_DIGEST=${BEFORE_DIGEST} >> $GITHUB_ENV
+        # Apply the sample task definition.
+        kubectl apply -f examples/task-hello.yaml
 
-    - name: Check out mink-apply-nodejs
-      uses: actions/checkout@v2
-      with:
-        repository: mattmoor/mink-apply-nodejs
-        path: ./src/github.com/mattmoor/mink-apply-nodejs
+        NAME=${RANDOM}
 
-    - name: Kontext bundle mink-apply-nodejs
-      working-directory: ./src/github.com/mattmoor/mink-apply-nodejs
-      run: |
-        AFTER_DIGEST=$(mink bundle)
-        if [[ "${BEFORE_DIGEST}" != "${AFTER_DIGEST}" ]]; then
-          echo "Git: ${BEFORE_DIGEST}, Kontext: ${AFTER_DIGEST}"
+        echo '::group:: Test w/o optional parameters'
+        WANT="Hello, ${NAME}"
+        GOT=$(mink run task hello -- --name ${NAME} -omessage)
+
+        if [[ "${GOT}" != "${WANT}" ]]; then
+          echo Got: ${GOT}, wanted ${WANT},
           exit 1
         fi
+        echo '::endgroup::'
+
+        echo '::group:: Test w/ optional parameters'
+        WANT="Hola, ${NAME}"
+        GOT=$(mink run task hello -- --name ${NAME} --greeting Hola -omessage)
+
+        if [[ "${GOT}" != "${WANT}" ]]; then
+          echo Got: ${GOT}, wanted ${WANT},
+          exit 1
+        fi
+        echo '::endgroup::'
+
+    - name: Test mink run pipeline
+      working-directory: ./src/github.com/mattmoor/mink
+      run: |
+        # Apply the sample task definition.
+        kubectl apply -f examples/pipeline-hello.yaml
+
+        NAME=${RANDOM}
+
+        echo '::group:: Test w/o optional parameters'
+        WANT="Hello, ${NAME}"
+        GOT=$(mink run pipeline hello-and-goodbye -- --name ${NAME} -ogreeting-message)
+
+        if [[ "${GOT}" != "${WANT}" ]]; then
+          echo Got: ${GOT}, wanted ${WANT},
+          exit 1
+        fi
+        echo '::endgroup::'
+
+        echo '::group:: Test w/ optional parameters'
+        WANT="Adios, ${NAME}"
+        GOT=$(mink run pipeline hello-and-goodbye -- --name ${NAME} --greeting Aloha --farewell Adios -ofarewell-message)
+
+        if [[ "${GOT}" != "${WANT}" ]]; then
+          echo Got: ${GOT}, wanted ${WANT},
+          exit 1
+        fi
+        echo '::endgroup::'
 
     - name: Collect system diagnostics
       if: ${{ failure() }}
@@ -135,6 +171,6 @@ jobs:
         SLACK_CHANNEL: 'mink'
         SLACK_COLOR: '#8E1600'
         MSG_MINIMAL: 'true'
-        SLACK_TITLE: Periodic bundle test failed on ${{ matrix.k8s-version }}.
+        SLACK_TITLE: Periodic run test failed on ${{ matrix.k8s-version }}.
         SLACK_MESSAGE: |
           For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/CLI.md
+++ b/CLI.md
@@ -211,3 +211,7 @@ Try this out with some of the community samples:
 ### Apply and Resolve
 
 For more on `mink apply` and `mink resolve` see [here](./APPLY.md).
+
+### Running Tasks and Pipelines
+
+For more on `mink run task` and `mink run pipeline` see [here](./RUN.md).

--- a/RUN.md
+++ b/RUN.md
@@ -1,0 +1,55 @@
+# Using `mink run`
+
+`mink run` allows users to instantiate named Tekton Task and Pipeline resources
+via `mink run task NAME` and `mink run pipeline NAME` respectively.  How they
+work is largely the same, just Tasks vs. Pipelines.
+
+## Usage
+
+If a task (similarly for pipelines) takes no arguments, it can be invoked with:
+
+```shell
+$ mink run task NAME
+```
+
+The usage of the task (or pipeline) itself can be examined with:
+
+```shell
+$ mink run task hello -- --help
+Says hello and stuff
+
+Usage:
+  mink run task hello [flags]
+
+Flags:
+      --greeting string   The greeting to use (default "Hello")
+  -h, --help              help for mink
+      --name string       The name of the person to greet.
+  -o, --output string     options: message
+```
+
+This usage draws all of its metadata from the task definition itself.  The task
+description, the parameters (descriptions and defaults), and the outputs (results).
+
+
+## Example
+
+To try things out, you can install the task `examples/task-hello.yaml` and
+invoke it with:
+
+```shell
+$  mink run task hello -- --name Bill
+[echo] Hello, Bill
+```
+
+You can project named results with `-oNAME`:
+
+```shell
+$ mink run task hello -- --name Bill -omessage
+[echo] Hello, Bill
+
+Hello, Bill
+```
+
+The result (`-oNAME`) will be sent to stdout, where the log output will be sent to
+stderr, so you can capture or compose the result while still seeing logs.

--- a/cmd/mink/main.go
+++ b/cmd/mink/main.go
@@ -74,6 +74,7 @@ func init() {
 	rootCmd.AddCommand(command.NewBundleCommand())
 	rootCmd.AddCommand(command.NewBuildCommand())
 	rootCmd.AddCommand(command.NewBuildpackCommand())
+	rootCmd.AddCommand(command.NewRunCommand())
 
 	rootCmd.AddCommand(command.NewResolveCommand())
 	rootCmd.AddCommand(command.NewApplyCommand())

--- a/examples/pipeline-hello.yaml
+++ b/examples/pipeline-hello.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: hello-and-goodbye
+spec:
+  description: "Says hello and goodbye"
+  params:
+    - name: name
+      description: The name of the person to greet.
+    - name: greeting
+      description: The greeting to use
+      default: "Hello"
+    - name: farewell
+      description: The farewell to use
+      default: "Goodbye"
+
+  results:
+  - name: greeting-message
+    description: The initial message
+    value: $(tasks.greet-them.results.message)
+  - name: farewell-message
+    description: The final message
+    value: $(tasks.send-them-off.results.message)
+
+  tasks:
+    - name: greet-them
+      taskRef:
+        name: hello
+      params:
+        - name: name
+          value: "$(params.name)"
+        - name: greeting
+          value: "$(params.greeting)"
+
+    - name: send-them-off
+      runAfter:
+      - greet-them
+      taskRef:
+        name: hello
+      params:
+        - name: name
+          value: "$(params.name)"
+        - name: greeting
+          value: "$(params.farewell)"

--- a/examples/task-hello.yaml
+++ b/examples/task-hello.yaml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: hello
+spec:
+  description: "Says hello and stuff"
+  params:
+    - name: name
+      description: The name of the person to greet.
+    - name: greeting
+      description: The greeting to use
+      default: "Hello"
+
+  results:
+  - name: message
+    description: The message that was printed
+
+  steps:
+    - name: echo
+      image: ubuntu
+      command:
+        - /bin/bash
+      args:
+        - -c
+        - echo "$(params.greeting), $(params.name)" | tee /tekton/results/message

--- a/pkg/builds/build.go
+++ b/pkg/builds/build.go
@@ -18,107 +18,40 @@ package builds
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
-	"log"
-	"math/rand"
 	"os"
 	"os/user"
 	"path/filepath"
 	"strings"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/tektoncd/cli/pkg/cmd/pipelinerun"
 	"github.com/tektoncd/cli/pkg/cmd/taskrun"
 	"github.com/tektoncd/cli/pkg/options"
 	tknv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	tektonclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"knative.dev/pkg/apis"
 )
-
-// CancelableOption is a function option that can be used to customize a taskrun in
-// certain ways prior to execution.  Each option may return a cancel function, which
-// can be used to clean up any temporary artifacts created in support of this task run.
-type CancelableOption func(context.Context, *tknv1beta1.TaskRun) (context.CancelFunc, error)
 
 // Run executes the provided TaskRun with the provided options applied, and returns
 // the fully-qualified image digest (or error) upon completion.
-func Run(ctx context.Context, image string, tr *tknv1beta1.TaskRun, opt *options.LogOptions, opts ...CancelableOption) (name.Digest, error) {
-	// TODO(mattmoor): expose masterURL and kubeconfig flags.
-	cfg, err := GetConfig("", "")
-	if err != nil {
-		return name.Digest{}, err
-	}
-	client, err := tektonclientset.NewForConfig(cfg)
+func Run(ctx context.Context, image string, tr *tknv1beta1.TaskRun, opt *options.LogOptions, opts ...CancelableTaskOption) (name.Digest, error) {
+	tr, err := RunTask(ctx, tr, opt, opts...)
 	if err != nil {
 		return name.Digest{}, err
 	}
 
-	for _, o := range opts {
-		cancel, err := o(ctx, tr)
-		if err != nil {
-			return name.Digest{}, err
-		}
-		defer cancel()
-	}
-
-	tr, err = client.TektonV1beta1().TaskRuns(tr.Namespace).Create(ctx, tr, metav1.CreateOptions{})
-	if err != nil {
-		return name.Digest{}, err
-	}
-
-	// TODO(mattmoor): From here down assumes opt.Follow, but if we want to have
-	// a --no-wait or something then we should have an early-out here.
-	defer client.TektonV1beta1().TaskRuns(tr.Namespace).Delete(context.Background(), tr.Name, metav1.DeleteOptions{})
-
-	opt.TaskrunName = tr.Name
-	if err := streamLogs(ctx, opt); err != nil {
-		return name.Digest{}, err
-	}
-
-	// Spin waiting for the final status.
-	for {
-		// See if our context has been cancelled
-		select {
-		case <-ctx.Done():
-			return name.Digest{}, ctx.Err()
-		default:
-		}
-
-		// Fetch the final state of the build.
-		tr, err = client.TektonV1beta1().TaskRuns(tr.Namespace).Get(ctx, tr.Name, metav1.GetOptions{})
-		if err != nil {
-			return name.Digest{}, err
-		}
-
-		// Return an error if the build failed.
-		cond := tr.Status.GetCondition(apis.ConditionSucceeded)
-		if cond.IsFalse() {
-			return name.Digest{}, fmt.Errorf("%s: %s", cond.Reason, cond.Message)
-		} else if !cond.IsTrue() {
+	for _, result := range tr.Status.TaskRunResults {
+		if result.Name != "IMAGE-DIGEST" {
 			continue
 		}
+		value := strings.TrimSpace(result.Value)
 
-		for _, result := range tr.Status.TaskRunResults {
-			if result.Name != "IMAGE-DIGEST" {
-				continue
-			}
-			value := strings.TrimSpace(result.Value)
-
-			// Extract the IMAGE-DIGEST result.
-			digest, err := name.NewDigest(image + "@" + value)
-			if err != nil {
-				return name.Digest{}, err
-			}
-
-			return digest, nil
-		}
+		// Extract the IMAGE-DIGEST result.
+		return name.NewDigest(image + "@" + value)
 	}
+	return name.Digest{}, errors.New("taskrun did not produce an IMAGE-DIGEST result")
 }
 
 func streamLogs(ctx context.Context, opt *options.LogOptions) error {
@@ -126,7 +59,12 @@ func streamLogs(ctx context.Context, opt *options.LogOptions) error {
 	errCh := make(chan error)
 	go func() {
 		defer close(errCh)
-		errCh <- taskrun.Run(opt)
+		switch {
+		case opt.TaskrunName != "":
+			errCh <- taskrun.Run(opt)
+		case opt.PipelineRunName != "":
+			errCh <- pipelinerun.Run(opt)
+		}
 	}()
 
 	select {
@@ -134,140 +72,6 @@ func streamLogs(ctx context.Context, opt *options.LogOptions) error {
 		return err
 	case <-ctx.Done():
 		return ctx.Err()
-	}
-}
-
-// WithServiceAccount is used to adjust the TaskRun to execute as a particular
-// service account, as specified by the user.  It supports a special "me" sentinel
-// which configures a temporary ServiceAccount infused with the local credentials
-// for the container registry hosting the image we will publish to (and to which
-// the source is published).
-func WithServiceAccount(sa string, refs ...name.Reference) CancelableOption {
-	cfg, err := GetConfig("", "")
-	if err != nil {
-		log.Fatal("GetConfig() =", err)
-	}
-	client := kubernetes.NewForConfigOrDie(cfg)
-
-	return func(ctx context.Context, tr *tknv1beta1.TaskRun) (context.CancelFunc, error) {
-		if sa != "me" {
-			tr.Spec.ServiceAccountName = sa
-			return func() {}, nil
-		}
-
-		cfg := struct {
-			Auths map[string]*authn.AuthConfig `json:"auths"`
-		}{
-			Auths: make(map[string]*authn.AuthConfig, len(refs)),
-		}
-
-		for _, ref := range refs {
-			// Fetch the user's auth for the provided build target
-			authenticator, err := authn.DefaultKeychain.Resolve(ref.Context())
-			if err != nil {
-				return nil, err
-			}
-			auth, err := authenticator.Authorization()
-			if err != nil {
-				return nil, err
-			}
-			// Use the funny form so that it works with DockerHub.
-			cfg.Auths["https://"+ref.Context().RegistryStr()+"/v1/"] = auth
-		}
-		b, err := json.Marshal(cfg)
-		if err != nil {
-			return nil, err
-		}
-
-		// Create a secret and service account for this build.
-		secret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: tr.GenerateName,
-				Namespace:    tr.Namespace,
-			},
-			Type: corev1.SecretTypeDockerConfigJson,
-			StringData: map[string]string{
-				corev1.DockerConfigJsonKey: string(b),
-			},
-		}
-		secret, err = client.CoreV1().Secrets(secret.Namespace).Create(ctx, secret, metav1.CreateOptions{})
-		if err != nil {
-			return nil, err
-		}
-		cleansecret := func() {
-			err := client.CoreV1().Secrets(secret.Namespace).Delete(context.Background(), secret.Name, metav1.DeleteOptions{})
-			if err != nil {
-				log.Printf("WARNING: Secret %q leaked, error cleaning up: %v", secret.Name, err)
-			}
-		}
-
-		sa := &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: tr.GenerateName,
-				Namespace:    tr.Namespace,
-			},
-			// Support pulling source using the user credentials.
-			ImagePullSecrets: []corev1.LocalObjectReference{{
-				Name: secret.Name,
-			}},
-		}
-		sa, err = client.CoreV1().ServiceAccounts(sa.Namespace).Create(ctx, sa, metav1.CreateOptions{})
-		if err != nil {
-			cleansecret()
-			return nil, err
-		}
-		cleansa := func() {
-			err := client.CoreV1().ServiceAccounts(sa.Namespace).Delete(context.Background(), sa.Name, metav1.DeleteOptions{})
-			if err != nil {
-				log.Printf("WARNING: ServiceAccount %q leaked, error cleaning up: %v", sa.Name, err)
-			}
-		}
-
-		tr.Spec.ServiceAccountName = sa.Name
-
-		// Mount the credentials secret as a volume.
-		//nolint:gosec Randomized to avoid collisions.
-		volumeName := fmt.Sprint("mink-creds-", rand.Uint64())
-		tr.Spec.TaskSpec.Volumes = append(tr.Spec.TaskSpec.Volumes, corev1.Volume{
-			Name: volumeName,
-			VolumeSource: corev1.VolumeSource{
-				Projected: &corev1.ProjectedVolumeSource{
-					Sources: []corev1.VolumeProjection{{
-						Secret: &corev1.SecretProjection{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: secret.Name,
-							},
-							Items: []corev1.KeyToPath{{
-								Key:  corev1.DockerConfigJsonKey,
-								Path: "config.json",
-								// Mode defaults to 0644
-							}},
-						},
-					}},
-				},
-			},
-		})
-		// How we will mount the credentials into steps.
-		vm := corev1.VolumeMount{
-			Name:      volumeName,
-			MountPath: fmt.Sprint("/var/mink/creds/", rand.Uint64()), //nolint:gosec // Randomize to avoid hardcoding (weak ok)
-		}
-
-		for i := range tr.Spec.TaskSpec.Steps {
-			for j, env := range tr.Spec.TaskSpec.Steps[i].Env {
-				if env.Name == "DOCKER_CONFIG" {
-					// When steps specify DOCKER_CONFIG, override it's value and attach our mount.
-					tr.Spec.TaskSpec.Steps[i].Env[j].Value = vm.MountPath
-					tr.Spec.TaskSpec.Steps[i].VolumeMounts = append(tr.Spec.TaskSpec.Steps[i].VolumeMounts, vm)
-					break
-				}
-			}
-		}
-
-		return func() {
-			cleansa()
-			cleansecret()
-		}, nil
 	}
 }
 

--- a/pkg/builds/pipeline.go
+++ b/pkg/builds/pipeline.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builds
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/tektoncd/cli/pkg/options"
+	tknv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	tektonclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
+
+// CancelablePipelineOption is a function option that can be used to customize a pipelinerun in
+// certain ways prior to execution.  Each option may return a cancel function, which
+// can be used to clean up any temporary artifacts created in support of this pipeline run.
+type CancelablePipelineOption func(context.Context, *tknv1beta1.PipelineRun) (context.CancelFunc, error)
+
+// RunPipeline executes the provided PipelineRun with the provided options applied, and returns
+// the final PipelineRun state (or error) upon completion.
+func RunPipeline(ctx context.Context, tr *tknv1beta1.PipelineRun, opt *options.LogOptions, opts ...CancelablePipelineOption) (*tknv1beta1.PipelineRun, error) {
+	// TODO(mattmoor): expose masterURL and kubeconfig flags.
+	cfg, err := GetConfig("", "")
+	if err != nil {
+		return nil, err
+	}
+	client, err := tektonclientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, o := range opts {
+		cancel, err := o(ctx, tr)
+		if err != nil {
+			return nil, err
+		}
+		defer cancel()
+	}
+
+	tr, err = client.TektonV1beta1().PipelineRuns(tr.Namespace).Create(ctx, tr, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(mattmoor): From here down assumes opt.Follow, but if we want to have
+	// a --no-wait or something then we should have an early-out here.
+	defer client.TektonV1beta1().PipelineRuns(tr.Namespace).Delete(context.Background(), tr.Name, metav1.DeleteOptions{})
+
+	opt.PipelineRunName = tr.Name
+	if err := streamLogs(ctx, opt); err != nil {
+		return nil, err
+	}
+
+	// Spin waiting for the final status.
+	for {
+		// See if our context has been cancelled
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		// Fetch the final state of the build.
+		tr, err = client.TektonV1beta1().PipelineRuns(tr.Namespace).Get(ctx, tr.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		// Return an error if the build failed.
+		cond := tr.Status.GetCondition(apis.ConditionSucceeded)
+		if cond.IsFalse() {
+			return nil, fmt.Errorf("%s: %s", cond.Reason, cond.Message)
+		} else if !cond.IsTrue() {
+			continue
+		}
+
+		return tr, nil
+	}
+}
+
+// WithPipelineServiceAccount is used to adjust the PipelineRun to execute as a particular
+// service account, as specified by the user.  It supports a special "me" sentinel
+// which configures a temporary ServiceAccount infused with the local credentials
+// for the container registry hosting the image we will publish to (and to which
+// the source is published).
+func WithPipelineServiceAccount(sa string, refs ...name.Reference) CancelablePipelineOption {
+	return func(ctx context.Context, tr *tknv1beta1.PipelineRun) (context.CancelFunc, error) {
+		if sa != "me" {
+			tr.Spec.ServiceAccountName = sa
+			return func() {}, nil
+		}
+		return nil, errors.New("--as=me is not yet supported for pipelines")
+	}
+}

--- a/pkg/builds/task.go
+++ b/pkg/builds/task.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/rand"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/tektoncd/cli/pkg/options"
+	tknv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	tektonclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/apis"
+)
+
+// CancelableTaskOption is a function option that can be used to customize a taskrun in
+// certain ways prior to execution.  Each option may return a cancel function, which
+// can be used to clean up any temporary artifacts created in support of this task run.
+type CancelableTaskOption func(context.Context, *tknv1beta1.TaskRun) (context.CancelFunc, error)
+
+// RunTask executes the provided TaskRun with the provided options applied, and returns
+// the final TaskRun state (or error) upon completion.
+func RunTask(ctx context.Context, tr *tknv1beta1.TaskRun, opt *options.LogOptions, opts ...CancelableTaskOption) (*tknv1beta1.TaskRun, error) {
+	// TODO(mattmoor): expose masterURL and kubeconfig flags.
+	cfg, err := GetConfig("", "")
+	if err != nil {
+		return nil, err
+	}
+	client, err := tektonclientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, o := range opts {
+		cancel, err := o(ctx, tr)
+		if err != nil {
+			return nil, err
+		}
+		defer cancel()
+	}
+
+	tr, err = client.TektonV1beta1().TaskRuns(tr.Namespace).Create(ctx, tr, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(mattmoor): From here down assumes opt.Follow, but if we want to have
+	// a --no-wait or something then we should have an early-out here.
+	defer client.TektonV1beta1().TaskRuns(tr.Namespace).Delete(context.Background(), tr.Name, metav1.DeleteOptions{})
+
+	opt.TaskrunName = tr.Name
+	if err := streamLogs(ctx, opt); err != nil {
+		return nil, err
+	}
+
+	// Spin waiting for the final status.
+	for {
+		// See if our context has been cancelled
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		// Fetch the final state of the build.
+		tr, err = client.TektonV1beta1().TaskRuns(tr.Namespace).Get(ctx, tr.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		// Return an error if the build failed.
+		cond := tr.Status.GetCondition(apis.ConditionSucceeded)
+		if cond.IsFalse() {
+			return nil, fmt.Errorf("%s: %s", cond.Reason, cond.Message)
+		} else if !cond.IsTrue() {
+			continue
+		}
+
+		return tr, nil
+	}
+}
+
+// WithTaskServiceAccount is used to adjust the TaskRun to execute as a particular
+// service account, as specified by the user.  It supports a special "me" sentinel
+// which configures a temporary ServiceAccount infused with the local credentials
+// for the container registry hosting the image we will publish to (and to which
+// the source is published).
+func WithTaskServiceAccount(sa string, refs ...name.Reference) CancelableTaskOption {
+	cfg, err := GetConfig("", "")
+	if err != nil {
+		log.Fatal("GetConfig() =", err)
+	}
+	client := kubernetes.NewForConfigOrDie(cfg)
+
+	return func(ctx context.Context, tr *tknv1beta1.TaskRun) (context.CancelFunc, error) {
+		if sa != "me" {
+			tr.Spec.ServiceAccountName = sa
+			return func() {}, nil
+		}
+
+		cfg := struct {
+			Auths map[string]*authn.AuthConfig `json:"auths"`
+		}{
+			Auths: make(map[string]*authn.AuthConfig, len(refs)),
+		}
+
+		for _, ref := range refs {
+			// Fetch the user's auth for the provided build target
+			authenticator, err := authn.DefaultKeychain.Resolve(ref.Context())
+			if err != nil {
+				return nil, err
+			}
+			auth, err := authenticator.Authorization()
+			if err != nil {
+				return nil, err
+			}
+			// Use the funny form so that it works with DockerHub.
+			cfg.Auths["https://"+ref.Context().RegistryStr()+"/v1/"] = auth
+		}
+		b, err := json.Marshal(cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		// Create a secret and service account for this build.
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: tr.GenerateName,
+				Namespace:    tr.Namespace,
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			StringData: map[string]string{
+				corev1.DockerConfigJsonKey: string(b),
+			},
+		}
+		secret, err = client.CoreV1().Secrets(secret.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+		if err != nil {
+			return nil, err
+		}
+		cleansecret := func() {
+			err := client.CoreV1().Secrets(secret.Namespace).Delete(context.Background(), secret.Name, metav1.DeleteOptions{})
+			if err != nil {
+				log.Printf("WARNING: Secret %q leaked, error cleaning up: %v", secret.Name, err)
+			}
+		}
+
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: tr.GenerateName,
+				Namespace:    tr.Namespace,
+			},
+			// Support pulling source using the user credentials.
+			ImagePullSecrets: []corev1.LocalObjectReference{{
+				Name: secret.Name,
+			}},
+		}
+		sa, err = client.CoreV1().ServiceAccounts(sa.Namespace).Create(ctx, sa, metav1.CreateOptions{})
+		if err != nil {
+			cleansecret()
+			return nil, err
+		}
+		cleansa := func() {
+			err := client.CoreV1().ServiceAccounts(sa.Namespace).Delete(context.Background(), sa.Name, metav1.DeleteOptions{})
+			if err != nil {
+				log.Printf("WARNING: ServiceAccount %q leaked, error cleaning up: %v", sa.Name, err)
+			}
+		}
+
+		tr.Spec.ServiceAccountName = sa.Name
+
+		// Mount the credentials secret as a volume.
+		//nolint:gosec Randomized to avoid collisions.
+		volumeName := fmt.Sprint("mink-creds-", rand.Uint64())
+		tr.Spec.TaskSpec.Volumes = append(tr.Spec.TaskSpec.Volumes, corev1.Volume{
+			Name: volumeName,
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{{
+						Secret: &corev1.SecretProjection{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: secret.Name,
+							},
+							Items: []corev1.KeyToPath{{
+								Key:  corev1.DockerConfigJsonKey,
+								Path: "config.json",
+								// Mode defaults to 0644
+							}},
+						},
+					}},
+				},
+			},
+		})
+		// How we will mount the credentials into steps.
+		vm := corev1.VolumeMount{
+			Name:      volumeName,
+			MountPath: fmt.Sprint("/var/mink/creds/", rand.Uint64()), //nolint:gosec // Randomize to avoid hardcoding (weak ok)
+		}
+
+		for i := range tr.Spec.TaskSpec.Steps {
+			for j, env := range tr.Spec.TaskSpec.Steps[i].Env {
+				if env.Name == "DOCKER_CONFIG" {
+					// When steps specify DOCKER_CONFIG, override it's value and attach our mount.
+					tr.Spec.TaskSpec.Steps[i].Env[j].Value = vm.MountPath
+					tr.Spec.TaskSpec.Steps[i].VolumeMounts = append(tr.Spec.TaskSpec.Steps[i].VolumeMounts, vm)
+					break
+				}
+			}
+		}
+
+		return func() {
+			cleansa()
+			cleansecret()
+		}, nil
+	}
+}

--- a/pkg/command/build.go
+++ b/pkg/command/build.go
@@ -181,5 +181,5 @@ func (opts *BuildOptions) build(ctx context.Context, sourceDigest name.Digest, w
 			Err: w,
 		},
 		Follow: true,
-	}, builds.WithServiceAccount(opts.ServiceAccount, tag, sourceDigest))
+	}, builds.WithTaskServiceAccount(opts.ServiceAccount, tag, sourceDigest))
 }

--- a/pkg/command/buildpacks.go
+++ b/pkg/command/buildpacks.go
@@ -184,5 +184,5 @@ func (opts *BuildpackOptions) build(ctx context.Context, sourceDigest name.Diges
 			Err: w,
 		},
 		Follow: true,
-	}, builds.WithServiceAccount(opts.ServiceAccount, tag, sourceDigest))
+	}, builds.WithTaskServiceAccount(opts.ServiceAccount, tag, sourceDigest))
 }

--- a/pkg/command/resolve.go
+++ b/pkg/command/resolve.go
@@ -414,7 +414,7 @@ func (opts *ResolveOptions) ko(ctx context.Context, source name.Digest, u *url.U
 			Err: buf,
 		},
 		Follow: true,
-	}, builds.WithServiceAccount(opts.ServiceAccount, tag, source))
+	}, builds.WithTaskServiceAccount(opts.ServiceAccount, tag, source))
 	if err != nil {
 		log.Print(buf.String())
 		return name.Digest{}, err

--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewRunCommand implements 'kn-im run' command
+func NewRunCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "<todo>",
+	}
+
+	cmd.AddCommand(NewRunTaskCommand())
+	cmd.AddCommand(NewRunPipelineCommand())
+
+	return cmd
+}

--- a/pkg/command/run_pipeline.go
+++ b/pkg/command/run_pipeline.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mattmoor/mink/pkg/builds"
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/options"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	tektonclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/signals"
+)
+
+var runPipelineExample = fmt.Sprintf(`
+  # Create a PipelineRun instantiating the pipeline "build-stuff" and passing
+  # values to named arguments.
+  %[1]s run pipeline build-stuff -- --arg1=val1 --arg2=val2
+`, ExamplePrefix())
+
+// NewRunPipelineCommand implements 'kn-im run pipeline' command
+func NewRunPipelineCommand() *cobra.Command {
+	opts := &RunPipelineOptions{}
+
+	cmd := &cobra.Command{
+		Use:          "pipeline NAME",
+		Short:        "Create a PipelineRun to execute a pipeline.",
+		Example:      runPipelineExample,
+		SilenceUsage: true,
+		Args: func(cmd *cobra.Command, args []string) error {
+			// The index of --
+			dashIdx := cmd.ArgsLenAtDash()
+
+			posArgs := args
+			if dashIdx != -1 {
+				posArgs = posArgs[:dashIdx]
+			}
+			// We want exactly one positional argument
+			// before a possible -- token.
+			return cobra.ExactArgs(1)(cmd, posArgs)
+		},
+		PreRunE: opts.Validate,
+		RunE:    opts.Execute,
+	}
+
+	opts.AddFlags(cmd)
+
+	return cmd
+}
+
+// RunPipelineOptions implements Interface for the `kn im run pipeline` command.
+type RunPipelineOptions struct {
+	// Inherit all of the base build options.
+	BaseBuildOptions
+}
+
+// RunPipelineOptions implements Interface
+var _ Interface = (*RunPipelineOptions)(nil)
+
+// AddFlags implements Interface
+func (opts *RunPipelineOptions) AddFlags(cmd *cobra.Command) {
+	// Add the bundle flags to our surface.
+	opts.BaseBuildOptions.AddFlags(cmd)
+
+}
+
+// Validate implements Interface
+func (opts *RunPipelineOptions) Validate(cmd *cobra.Command, args []string) error {
+	// Validate the bundle arguments.
+	if err := opts.BaseBuildOptions.Validate(cmd, args); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Execute implements Interface
+func (opts *RunPipelineOptions) Execute(cmd *cobra.Command, args []string) error {
+	ctx := signals.NewContext()
+
+	// TODO(mattmoor): expose masterURL and kubeconfig flags.
+	cfg, err := builds.GetConfig("", "")
+	if err != nil {
+		return err
+	}
+	client, err := tektonclientset.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	// Load the pipeline definition.
+	pipelineName := args[0]
+	pipeline, err := client.TektonV1beta1().Pipelines(Namespace()).Get(ctx, pipelineName, metav1.GetOptions{})
+	if apierrs.IsNotFound(err) {
+		cmd.Printf("Pipeline %q not found\n", fmt.Sprintf("%s/%s", Namespace(), pipelineName))
+		return err
+	} else if err != nil {
+		return err
+	}
+
+	// The (optional) name of the "result" to output to STDOUT.
+	// TODO(mattmoor): Task/Pipeline don't share a type, which makes
+	// sharing the result logic harder than it should be.
+	var result *string
+
+	pipelineCmd := &cobra.Command{
+		Use:   "mink run pipeline " + pipeline.Name,
+		Short: pipeline.Spec.Description,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pr := &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    Namespace(),
+					GenerateName: "mink-" + pipeline.Name + "-",
+				},
+				Spec: v1beta1.PipelineRunSpec{
+					Params: make([]v1beta1.Param, 0, len(pipeline.Spec.Params)),
+					PipelineRef: &v1beta1.PipelineRef{
+						Name: pipeline.Name,
+					},
+				},
+			}
+
+			for _, param := range pipeline.Spec.Params {
+				f := cmd.Flags().Lookup(param.Name)
+
+				if param.Default == nil && f.Value.String() == "" {
+					return apis.ErrMissingField(param.Name)
+				}
+
+				pr.Spec.Params = append(pr.Spec.Params, v1beta1.Param{
+					Name:  param.Name,
+					Value: *v1beta1.NewArrayOrString(f.Value.String()),
+				})
+			}
+
+			pr, err := builds.RunPipeline(ctx, pr, &options.LogOptions{
+				Params: &cli.TektonParams{},
+				Stream: &cli.Stream{
+					// Send Out to stderr so we can capture the digest for composition.
+					Out: cmd.OutOrStderr(),
+					Err: cmd.OutOrStderr(),
+				},
+				Follow: true,
+			}, builds.WithPipelineServiceAccount(opts.ServiceAccount))
+			if err != nil {
+				return err
+			}
+
+			// If running the pipeline succeeded, then handle formatting the results as output.
+			if result != nil {
+				for _, r := range pr.Status.PipelineResults {
+					if r.Name != *result {
+						continue
+					}
+					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", strings.TrimSpace(r.Value))
+				}
+			}
+			return nil
+		},
+	}
+
+	for _, param := range pipeline.Spec.Params {
+		switch param.Type {
+		case v1beta1.ParamTypeArray:
+			// TODO(mattmoor): Any magic for this?
+			// If all else fails: https://stackoverflow.com/questions/28322997/how-to-get-a-list-of-values-into-a-flag-in-golang
+			return fmt.Errorf("unsupported parameter type array: %q", param.Name)
+		default:
+			// TODO(mattmoor): Look for arguments with a particular name, to signal the bundle logic.
+
+			if param.Default != nil {
+				pipelineCmd.Flags().String(param.Name, param.Default.StringVal, param.Description)
+			} else {
+				pipelineCmd.Flags().String(param.Name, "", param.Description)
+			}
+		}
+	}
+
+	if len(pipeline.Spec.Results) > 0 {
+		result = new(string)
+
+		// TODO(mattmoor): Validate supported "options" values.
+		options := make([]string, 0, len(pipeline.Spec.Results))
+		for _, result := range pipeline.Spec.Results {
+			options = append(options, result.Name)
+		}
+		// TODO(mattmoor): Incorporate the output descriptions.
+		pipelineCmd.Flags().StringVarP(result, "output", "o", "", "options: "+strings.Join(options, ", "))
+	}
+
+	pipelineCmd.SetArgs(args[1:])
+
+	return pipelineCmd.Execute()
+}

--- a/pkg/command/run_task.go
+++ b/pkg/command/run_task.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mattmoor/mink/pkg/builds"
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/options"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	tektonclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/signals"
+)
+
+var runTaskExample = fmt.Sprintf(`
+  # Create a TaskRun instantiating the task "build-stuff" and passing
+  # values to named arguments.
+  %[1]s run task build-stuff -- --arg1=val1 --arg2=val2
+`, ExamplePrefix())
+
+// NewRunTaskCommand implements 'kn-im run task' command
+func NewRunTaskCommand() *cobra.Command {
+	opts := &RunTaskOptions{}
+
+	cmd := &cobra.Command{
+		Use:          "task NAME",
+		Short:        "Create a TaskRun to execute a task.",
+		Example:      runTaskExample,
+		SilenceUsage: true,
+		Args: func(cmd *cobra.Command, args []string) error {
+			// The index of --
+			dashIdx := cmd.ArgsLenAtDash()
+
+			posArgs := args
+			if dashIdx != -1 {
+				posArgs = posArgs[:dashIdx]
+			}
+			// We want exactly one positional argument
+			// before a possible -- token.
+			return cobra.ExactArgs(1)(cmd, posArgs)
+		},
+		PreRunE: opts.Validate,
+		RunE:    opts.Execute,
+	}
+
+	opts.AddFlags(cmd)
+
+	return cmd
+}
+
+// RunTaskOptions implements Interface for the `kn im run task` command.
+type RunTaskOptions struct {
+	// Inherit all of the base build options.
+	BaseBuildOptions
+}
+
+// RunTaskOptions implements Interface
+var _ Interface = (*RunTaskOptions)(nil)
+
+// AddFlags implements Interface
+func (opts *RunTaskOptions) AddFlags(cmd *cobra.Command) {
+	// Add the bundle flags to our surface.
+	opts.BaseBuildOptions.AddFlags(cmd)
+
+}
+
+// Validate implements Interface
+func (opts *RunTaskOptions) Validate(cmd *cobra.Command, args []string) error {
+	// Validate the bundle arguments.
+	if err := opts.BaseBuildOptions.Validate(cmd, args); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Execute implements Interface
+func (opts *RunTaskOptions) Execute(cmd *cobra.Command, args []string) error {
+	ctx := signals.NewContext()
+
+	// TODO(mattmoor): expose masterURL and kubeconfig flags.
+	cfg, err := builds.GetConfig("", "")
+	if err != nil {
+		return err
+	}
+	client, err := tektonclientset.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	// Load the task definition.
+	taskName := args[0]
+	task, err := client.TektonV1beta1().Tasks(Namespace()).Get(ctx, taskName, metav1.GetOptions{})
+	if apierrs.IsNotFound(err) {
+		cmd.Printf("Task %q not found\n", fmt.Sprintf("%s/%s", Namespace(), taskName))
+		return err
+	} else if err != nil {
+		return err
+	}
+
+	// The (optional) name of the "result" to output to STDOUT.
+	// TODO(mattmoor): Task/Pipeline don't share a type, which makes
+	// sharing the result logic harder than it should be.
+	var result *string
+
+	taskCmd := &cobra.Command{
+		Use:   "mink run task " + task.Name,
+		Short: task.Spec.Description,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			tr := &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    Namespace(),
+					GenerateName: "mink-" + task.Name + "-",
+				},
+				Spec: v1beta1.TaskRunSpec{
+					Params: make([]v1beta1.Param, 0, len(task.Spec.Params)),
+					TaskRef: &v1beta1.TaskRef{
+						Name: task.Name,
+					},
+				},
+			}
+
+			for _, param := range task.Spec.Params {
+				f := cmd.Flags().Lookup(param.Name)
+
+				if param.Default == nil && f.Value.String() == "" {
+					return apis.ErrMissingField(param.Name)
+				}
+
+				tr.Spec.Params = append(tr.Spec.Params, v1beta1.Param{
+					Name:  param.Name,
+					Value: *v1beta1.NewArrayOrString(f.Value.String()),
+				})
+			}
+
+			tr, err := builds.RunTask(ctx, tr, &options.LogOptions{
+				Params: &cli.TektonParams{},
+				Stream: &cli.Stream{
+					// Send Out to stderr so we can capture the digest for composition.
+					Out: cmd.OutOrStderr(),
+					Err: cmd.OutOrStderr(),
+				},
+				Follow: true,
+			}, builds.WithTaskServiceAccount(opts.ServiceAccount))
+			if err != nil {
+				return err
+			}
+
+			// If running the task succeeded, then handle formatting the results as output.
+			if result != nil {
+				for _, r := range tr.Status.TaskRunResults {
+					if r.Name != *result {
+						continue
+					}
+					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", strings.TrimSpace(r.Value))
+				}
+			}
+			return nil
+		},
+	}
+
+	for _, param := range task.Spec.Params {
+		switch param.Type {
+		case v1beta1.ParamTypeArray:
+			// TODO(mattmoor): Any magic for this?
+			// If all else fails: https://stackoverflow.com/questions/28322997/how-to-get-a-list-of-values-into-a-flag-in-golang
+			return fmt.Errorf("unsupported parameter type array: %q", param.Name)
+		default:
+			// TODO(mattmoor): Look for arguments with a particular name, to signal the bundle logic.
+
+			if param.Default != nil {
+				taskCmd.Flags().String(param.Name, param.Default.StringVal, param.Description)
+			} else {
+				taskCmd.Flags().String(param.Name, "", param.Description)
+			}
+		}
+	}
+
+	if len(task.Spec.Results) > 0 {
+		result = new(string)
+
+		// TODO(mattmoor): Validate supported "options" values.
+		options := make([]string, 0, len(task.Spec.Results))
+		for _, result := range task.Spec.Results {
+			options = append(options, result.Name)
+		}
+		// TODO(mattmoor): Incorporate the output descriptions.
+		taskCmd.Flags().StringVarP(result, "output", "o", "", "options: "+strings.Join(options, ", "))
+	}
+
+	taskCmd.SetArgs(args[1:])
+
+	return taskCmd.Execute()
+}

--- a/vendor/github.com/tektoncd/cli/pkg/cmd/pipelinerun/cancel.go
+++ b/vendor/github.com/tektoncd/cli/pkg/cmd/pipelinerun/cancel.go
@@ -1,0 +1,82 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelinerun
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/pipelinerun"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func cancelCommand(p cli.Params) *cobra.Command {
+	eg := `Cancel the PipelineRun named 'foo' from namespace 'bar':
+
+    tkn pipelinerun cancel foo -n bar
+`
+
+	c := &cobra.Command{
+		Use:          "cancel",
+		Short:        "Cancel a PipelineRun in a namespace",
+		Example:      eg,
+		SilenceUsage: true,
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pr := args[0]
+
+			s := &cli.Stream{
+				Out: cmd.OutOrStdout(),
+				Err: cmd.OutOrStderr(),
+			}
+
+			return cancelPipelineRun(p, s, pr)
+		},
+	}
+
+	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipelinerun")
+	return c
+}
+
+func cancelPipelineRun(p cli.Params, s *cli.Stream, prName string) error {
+	cs, err := p.Clients()
+	if err != nil {
+		return fmt.Errorf("failed to create tekton client")
+	}
+
+	pr, err := pipelinerun.GetV1beta1(cs, prName, metav1.GetOptions{}, p.Namespace())
+	if err != nil {
+		return fmt.Errorf("failed to find PipelineRun: %s", prName)
+	}
+
+	if len(pr.Status.Conditions) > 0 {
+		if pr.Status.Conditions[0].Status != corev1.ConditionUnknown {
+			return fmt.Errorf("failed to cancel PipelineRun %s: PipelineRun has already finished execution", prName)
+		}
+	}
+
+	if _, err = pipelinerun.Patch(cs, prName, metav1.PatchOptions{}, p.Namespace()); err != nil {
+		return fmt.Errorf("failed to cancel PipelineRun: %s: %v", prName, err)
+
+	}
+
+	fmt.Fprintf(s.Out, "PipelineRun cancelled: %s\n", pr.Name)
+	return nil
+}

--- a/vendor/github.com/tektoncd/cli/pkg/cmd/pipelinerun/delete.go
+++ b/vendor/github.com/tektoncd/cli/pkg/cmd/pipelinerun/delete.go
@@ -1,0 +1,181 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelinerun
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/actions"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/deleter"
+	"github.com/tektoncd/cli/pkg/options"
+	pr "github.com/tektoncd/cli/pkg/pipelinerun"
+	prsort "github.com/tektoncd/cli/pkg/pipelinerun/sort"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func deleteCommand(p cli.Params) *cobra.Command {
+	opts := &options.DeleteOptions{Resource: "PipelineRun", ForceDelete: false, ParentResource: "Pipeline", DeleteAllNs: false}
+	f := cliopts.NewPrintFlags("delete")
+	eg := `Delete PipelineRuns with names 'foo' and 'bar' in namespace 'quux':
+
+    tkn pipelinerun delete foo bar -n quux
+
+or
+
+    tkn pr rm foo bar -n quux
+`
+
+	c := &cobra.Command{
+		Use:          "delete",
+		Aliases:      []string{"rm"},
+		Short:        "Delete PipelineRuns in a namespace",
+		Example:      eg,
+		Args:         cobra.MinimumNArgs(0),
+		SilenceUsage: true,
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			s := &cli.Stream{
+				In:  cmd.InOrStdin(),
+				Out: cmd.OutOrStdout(),
+				Err: cmd.OutOrStderr(),
+			}
+
+			if opts.Keep < 0 {
+				return fmt.Errorf("keep option should not be lower than 0")
+			}
+
+			if opts.Keep > 0 && opts.ParentResourceName == "" {
+				opts.DeleteAllNs = true
+			}
+
+			if err := opts.CheckOptions(s, args, p.Namespace()); err != nil {
+				return err
+			}
+
+			return deletePipelineRuns(s, p, args, opts)
+		},
+	}
+	f.AddFlags(c)
+	c.Flags().BoolVarP(&opts.ForceDelete, "force", "f", false, "Whether to force deletion (default: false)")
+	c.Flags().StringVarP(&opts.ParentResourceName, "pipeline", "p", "", "The name of a Pipeline whose PipelineRuns should be deleted (does not delete the Pipeline)")
+	c.Flags().IntVarP(&opts.Keep, "keep", "", 0, "Keep n most recent number of PipelineRuns")
+	c.Flags().BoolVarP(&opts.DeleteAllNs, "all", "", false, "Delete all PipelineRuns in a namespace (default: false)")
+	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipelinerun")
+	return c
+}
+
+func deletePipelineRuns(s *cli.Stream, p cli.Params, prNames []string, opts *options.DeleteOptions) error {
+	prGroupResource := schema.GroupVersionResource{Group: "tekton.dev", Resource: "pipelineruns"}
+
+	cs, err := p.Clients()
+	if err != nil {
+		return fmt.Errorf("failed to create tekton client")
+	}
+	var d *deleter.Deleter
+	switch {
+	case opts.DeleteAllNs:
+		d = deleter.New("PipelineRun", func(pipelineRunName string) error {
+			return actions.Delete(prGroupResource, cs, pipelineRunName, p.Namespace(), metav1.DeleteOptions{})
+		})
+		prs, err := allPipelineRunNames(cs, opts.Keep, p.Namespace())
+		if err != nil {
+			return err
+		}
+		d.Delete(s, prs)
+	case opts.ParentResourceName == "":
+		d = deleter.New("PipelineRun", func(pipelineRunName string) error {
+			return actions.Delete(prGroupResource, cs, pipelineRunName, p.Namespace(), metav1.DeleteOptions{})
+		})
+		d.Delete(s, prNames)
+	default:
+		d = deleter.New("Pipeline", func(_ string) error {
+			return errors.New("the Pipeline should not be deleted")
+		})
+		d.WithRelated("PipelineRun", pipelineRunLister(cs, opts.Keep, p.Namespace()), func(pipelineRunName string) error {
+			return actions.Delete(prGroupResource, cs, pipelineRunName, p.Namespace(), metav1.DeleteOptions{})
+		})
+		d.DeleteRelated(s, []string{opts.ParentResourceName})
+	}
+	if !opts.DeleteAllNs {
+		if d.Errors() == nil {
+			switch {
+			case opts.Keep > 0:
+				// Should only occur in case of --pipeline and --keep being used together
+				fmt.Fprintf(s.Out, "All but %d PipelineRuns associated with Pipeline %q deleted in namespace %q\n", opts.Keep, opts.ParentResourceName, p.Namespace())
+			case opts.ParentResourceName != "":
+				fmt.Fprintf(s.Out, "All PipelineRuns associated with Pipeline %q deleted in namespace %q\n", opts.ParentResourceName, p.Namespace())
+			default:
+				d.PrintSuccesses(s)
+			}
+		}
+	} else if opts.DeleteAllNs {
+		if d.Errors() == nil {
+			if opts.Keep > 0 {
+				fmt.Fprintf(s.Out, "All but %d PipelineRuns deleted in namespace %q\n", opts.Keep, p.Namespace())
+			} else {
+				fmt.Fprintf(s.Out, "All PipelineRuns deleted in namespace %q\n", p.Namespace())
+			}
+		}
+	}
+	return d.Errors()
+}
+
+func pipelineRunLister(cs *cli.Clients, keep int, ns string) func(string) ([]string, error) {
+	return func(pipelineName string) ([]string, error) {
+		lOpts := metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("tekton.dev/pipeline=%s", pipelineName),
+		}
+		pipelineRuns, err := pr.List(cs, lOpts, ns)
+		if err != nil {
+			return nil, err
+		}
+		return keepPipelineRuns(pipelineRuns, keep), nil
+	}
+}
+
+func allPipelineRunNames(cs *cli.Clients, keep int, ns string) ([]string, error) {
+	pipelineRuns, err := pr.List(cs, metav1.ListOptions{}, ns)
+	if err != nil {
+		return nil, err
+	}
+	return keepPipelineRuns(pipelineRuns, keep), nil
+}
+
+func keepPipelineRuns(pipelineRuns *v1beta1.PipelineRunList, keep int) []string {
+	var names []string
+	var counter = 0
+
+	// Do not sort PipelineRuns if keep=0 since ordering won't matter
+	if keep > 0 {
+		prsort.SortByStartTime(pipelineRuns.Items)
+	}
+
+	for _, run := range pipelineRuns.Items {
+		if keep > 0 && counter != keep {
+			counter++
+			continue
+		}
+		names = append(names, run.Name)
+	}
+	return names
+}

--- a/vendor/github.com/tektoncd/cli/pkg/cmd/pipelinerun/describe.go
+++ b/vendor/github.com/tektoncd/cli/pkg/cmd/pipelinerun/describe.go
@@ -1,0 +1,144 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelinerun
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/actions"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/options"
+	prhelper "github.com/tektoncd/cli/pkg/pipelinerun"
+	prdesc "github.com/tektoncd/cli/pkg/pipelinerun/description"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+const (
+	defaultDescribeLimit = 5
+)
+
+func describeCommand(p cli.Params) *cobra.Command {
+	f := cliopts.NewPrintFlags("describe")
+	opts := &options.DescribeOptions{Params: p}
+	eg := `Describe a PipelineRun of name 'foo' in namespace 'bar':
+
+    tkn pipelinerun describe foo -n bar
+
+or
+
+    tkn pr desc foo -n bar
+`
+
+	c := &cobra.Command{
+		Use:          "describe",
+		Aliases:      []string{"desc"},
+		Short:        "Describe a PipelineRun in a namespace",
+		Example:      eg,
+		SilenceUsage: true,
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			s := &cli.Stream{
+				Out: cmd.OutOrStdout(),
+				Err: cmd.OutOrStderr(),
+			}
+
+			output, err := cmd.LocalFlags().GetString("output")
+			if err != nil {
+				return fmt.Errorf("output option not set properly: %v", err)
+			}
+
+			if !opts.Fzf {
+				if _, ok := os.LookupEnv("TKN_USE_FZF"); ok {
+					opts.Fzf = true
+				}
+			}
+
+			if len(args) == 0 {
+				lOpts := metav1.ListOptions{}
+				if !opts.Last {
+					prs, err := prhelper.GetAllPipelineRuns(p, lOpts, opts.Limit)
+					if err != nil {
+						return err
+					}
+					if len(prs) == 1 {
+						opts.PipelineRunName = strings.Fields(prs[0])[0]
+					} else {
+						err = askPipelineRunName(opts, prs)
+						if err != nil {
+							return err
+						}
+					}
+				} else {
+					prs, err := prhelper.GetAllPipelineRuns(p, lOpts, 1)
+					if err != nil {
+						return err
+					}
+					if len(prs) == 0 {
+						fmt.Fprintf(s.Out, "No PipelineRuns present in namespace %s\n", opts.Params.Namespace())
+						return nil
+					}
+					opts.PipelineRunName = strings.Fields(prs[0])[0]
+				}
+			} else {
+				opts.PipelineRunName = args[0]
+			}
+
+			if output != "" {
+				pipelineRunGroupResource := schema.GroupVersionResource{Group: "tekton.dev", Resource: "pipelineruns"}
+				return actions.PrintObject(pipelineRunGroupResource, opts.PipelineRunName, cmd.OutOrStdout(), p, f, p.Namespace())
+			}
+
+			return prdesc.PrintPipelineRunDescription(s, opts.PipelineRunName, p)
+		},
+	}
+
+	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show description for last PipelineRun")
+	c.Flags().IntVarP(&opts.Limit, "limit", "", defaultDescribeLimit, "lists number of PipelineRuns when selecting a PipelineRun to describe")
+	c.Flags().BoolVarP(&opts.Fzf, "fzf", "F", false, "use fzf to select a PipelineRun to describe")
+
+	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipelinerun")
+	f.AddFlags(c)
+
+	return c
+}
+
+func askPipelineRunName(opts *options.DescribeOptions, prs []string) error {
+	err := opts.ValidateOpts()
+	if err != nil {
+		return err
+	}
+
+	if len(prs) == 0 {
+		return fmt.Errorf("no PipelineRuns found")
+	}
+
+	if opts.Fzf {
+		err = opts.FuzzyAsk(options.ResourceNamePipelineRun, prs)
+	} else {
+		err = opts.Ask(options.ResourceNamePipelineRun, prs)
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/tektoncd/cli/pkg/cmd/pipelinerun/list.go
+++ b/vendor/github.com/tektoncd/cli/pkg/cmd/pipelinerun/list.go
@@ -1,0 +1,239 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelinerun
+
+import (
+	"fmt"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/formatted"
+	"github.com/tektoncd/cli/pkg/pipelinerun"
+	prsort "github.com/tektoncd/cli/pkg/pipelinerun/sort"
+	"github.com/tektoncd/cli/pkg/printer"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cliopts "k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+const listTemplate = `{{- $prl := len .PipelineRuns.Items -}}{{- if eq $prl 0 -}}
+No PipelineRuns found
+{{ else -}}
+{{- if not $.NoHeaders -}}
+{{- if $.AllNamespaces -}}
+NAMESPACE	NAME	STARTED	DURATION	STATUS
+{{ else -}}
+NAME	STARTED	DURATION	STATUS
+{{ end -}}
+{{- end -}}
+{{- range $_, $pr := .PipelineRuns.Items }}{{- if $pr }}{{- if $.AllNamespaces -}}
+{{ $pr.Namespace }}	{{ $pr.Name }}	{{ formatAge $pr.Status.StartTime $.Time }}	{{ formatDuration $pr.Status.StartTime $pr.Status.CompletionTime }}	{{ formatCondition $pr.Status.Conditions }}
+{{ else -}}
+{{ $pr.Name }}	{{ formatAge $pr.Status.StartTime $.Time }}	{{ formatDuration $pr.Status.StartTime $pr.Status.CompletionTime }}	{{ formatCondition $pr.Status.Conditions }}
+{{ end -}}{{- end -}}{{- end -}}
+{{- end -}}`
+
+type ListOptions struct {
+	Limit         int
+	LabelSelector string
+	Reverse       bool
+	AllNamespaces bool
+	NoHeaders     bool
+}
+
+func listCommand(p cli.Params) *cobra.Command {
+
+	opts := &ListOptions{Limit: 0}
+	f := cliopts.NewPrintFlags("list")
+	eg := `List all PipelineRuns of Pipeline 'foo':
+
+    tkn pipelinerun list foo -n bar
+
+List all PipelineRuns in a namespace 'foo':
+
+    tkn pr list -n foo
+`
+
+	c := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "Lists PipelineRuns in a namespace",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		Example: eg,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var pipeline string
+
+			if len(args) > 0 {
+				pipeline = args[0]
+			}
+
+			if opts.Limit < 0 {
+				return fmt.Errorf("limit was %d but must be a positive number", opts.Limit)
+			}
+
+			prs, err := list(p, pipeline, opts.Limit, opts.LabelSelector, opts.AllNamespaces)
+			if err != nil {
+				return fmt.Errorf("failed to list PipelineRuns from namespace %s: %v", p.Namespace(), err)
+			}
+
+			if prs != nil && opts.Reverse {
+				reverse(prs)
+			}
+
+			output, err := cmd.LocalFlags().GetString("output")
+			if err != nil {
+				return fmt.Errorf("output option not set properly: %v", err)
+			}
+
+			if output == "name" && prs != nil {
+				w := cmd.OutOrStdout()
+				for _, pr := range prs.Items {
+					_, err := fmt.Fprintf(w, "pipelinerun.tekton.dev/%s\n", pr.Name)
+					if err != nil {
+						return err
+					}
+				}
+				return nil
+			} else if output != "" && prs != nil {
+				return printer.PrintObject(cmd.OutOrStdout(), prs, f)
+			}
+			stream := &cli.Stream{
+				Out: cmd.OutOrStdout(),
+				Err: cmd.OutOrStderr(),
+			}
+
+			if prs != nil {
+				err = printFormatted(stream, prs, p.Time(), opts.AllNamespaces, opts.NoHeaders)
+			}
+			if err != nil {
+				return fmt.Errorf("failed to print PipelineRuns: %v", err)
+			}
+
+			return nil
+		},
+	}
+
+	f.AddFlags(c)
+	c.Flags().IntVarP(&opts.Limit, "limit", "", 0, "limit PipelineRuns listed (default: return all PipelineRuns)")
+	c.Flags().StringVarP(&opts.LabelSelector, "label", "", opts.LabelSelector, "A selector (label query) to filter on, supports '=', '==', and '!='")
+	c.Flags().BoolVarP(&opts.Reverse, "reverse", "", opts.Reverse, "list PipelineRuns in reverse order")
+	c.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", opts.AllNamespaces, "list PipelineRuns from all namespaces")
+	c.Flags().BoolVarP(&opts.NoHeaders, "no-headers", "", opts.NoHeaders, "do not print column headers with output (default print column headers with output)")
+	return c
+}
+
+func list(p cli.Params, pipeline string, limit int, labelselector string, allnamespaces bool) (*v1beta1.PipelineRunList, error) {
+	var selector string
+	var options v1.ListOptions
+
+	cs, err := p.Clients()
+	if err != nil {
+		return nil, err
+	}
+
+	if pipeline != "" && labelselector != "" {
+		return nil, fmt.Errorf("specifying a Pipeline and labels are not compatible")
+	}
+
+	if pipeline != "" {
+		selector = fmt.Sprintf("tekton.dev/pipeline=%s", pipeline)
+	} else if labelselector != "" {
+		selector = labelselector
+	}
+
+	if selector != "" {
+		options = v1.ListOptions{
+			LabelSelector: selector,
+		}
+	}
+
+	ns := p.Namespace()
+	if allnamespaces {
+		ns = ""
+	}
+	prs, err := pipelinerun.List(cs, options, ns)
+	if err != nil {
+		return nil, err
+	}
+
+	prslen := len(prs.Items)
+
+	if prslen != 0 {
+		if allnamespaces {
+			prsort.SortByNamespace(prs.Items)
+		} else {
+			prsort.SortByStartTime(prs.Items)
+		}
+	}
+
+	// If greater than maximum amount of pipelineruns, return all pipelineruns by setting limit to default
+	if limit > prslen {
+		limit = 0
+	}
+
+	// Return all pipelineruns if limit is 0 or is same as prslen
+	if limit != 0 && prslen > limit {
+		prs.Items = prs.Items[0:limit]
+	}
+
+	return prs, nil
+}
+
+func reverse(prs *v1beta1.PipelineRunList) {
+	i := 0
+	j := len(prs.Items) - 1
+	prItems := prs.Items
+	for i < j {
+		prItems[i], prItems[j] = prItems[j], prItems[i]
+		i++
+		j--
+	}
+	prs.Items = prItems
+}
+
+func printFormatted(s *cli.Stream, prs *v1beta1.PipelineRunList, c clockwork.Clock, allnamespaces bool, noheaders bool) error {
+	var data = struct {
+		PipelineRuns  *v1beta1.PipelineRunList
+		Time          clockwork.Clock
+		AllNamespaces bool
+		NoHeaders     bool
+	}{
+		PipelineRuns:  prs,
+		Time:          c,
+		AllNamespaces: allnamespaces,
+		NoHeaders:     noheaders,
+	}
+
+	funcMap := template.FuncMap{
+		"formatAge":       formatted.Age,
+		"formatDuration":  formatted.Duration,
+		"formatCondition": formatted.Condition,
+	}
+
+	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
+	t := template.Must(template.New("List PipelineRuns").Funcs(funcMap).Parse(listTemplate))
+
+	err := t.Execute(w, data)
+	if err != nil {
+		return err
+	}
+
+	return w.Flush()
+}

--- a/vendor/github.com/tektoncd/cli/pkg/cmd/pipelinerun/logs.go
+++ b/vendor/github.com/tektoncd/cli/pkg/cmd/pipelinerun/logs.go
@@ -1,0 +1,141 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelinerun
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/log"
+	"github.com/tektoncd/cli/pkg/options"
+	prhelper "github.com/tektoncd/cli/pkg/pipelinerun"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	defaultLimit = 5
+)
+
+func logCommand(p cli.Params) *cobra.Command {
+	opts := &options.LogOptions{Params: p}
+	eg := `Show the logs of PipelineRun named 'foo' from namespace 'bar':
+
+    tkn pipelinerun logs foo -n bar
+
+Show the logs of PipelineRun named 'microservice-1' for Task 'build' only from namespace 'bar':
+
+    tkn pr logs microservice-1 -t build -n bar
+
+Show the logs of PipelineRun named 'microservice-1' for all Tasks and steps (including init steps) from namespace 'foo':
+
+    tkn pr logs microservice-1 -a -n foo
+   `
+
+	c := &cobra.Command{
+		Use:                   "logs",
+		DisableFlagsInUseLine: true,
+		Short:                 "Show the logs of a PipelineRun",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		Example: eg,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				opts.PipelineRunName = args[0]
+			}
+
+			if !opts.Fzf {
+				if _, ok := os.LookupEnv("TKN_USE_FZF"); ok {
+					opts.Fzf = true
+				}
+			}
+
+			opts.Stream = &cli.Stream{
+				Out: cmd.OutOrStdout(),
+				Err: cmd.OutOrStderr(),
+			}
+
+			return Run(opts)
+		},
+	}
+
+	c.Flags().BoolVarP(&opts.AllSteps, "all", "a", false, "show all logs including init steps injected by tekton")
+	c.Flags().BoolVarP(&opts.Last, "last", "L", false, "show logs for last PipelineRun")
+	c.Flags().BoolVarP(&opts.Fzf, "fzf", "F", false, "use fzf to select a PipelineRun")
+	c.Flags().BoolVarP(&opts.Follow, "follow", "f", false, "stream live logs")
+	c.Flags().StringSliceVarP(&opts.Tasks, "task", "t", []string{}, "show logs for mentioned Tasks only")
+	c.Flags().IntVarP(&opts.Limit, "limit", "", defaultLimit, "lists number of PipelineRuns")
+
+	_ = c.MarkZshCompPositionalArgumentCustom(1, "__tkn_get_pipelinerun")
+	return c
+}
+
+func Run(opts *options.LogOptions) error {
+	if opts.PipelineRunName == "" {
+		if err := opts.ValidateOpts(); err != nil {
+			return err
+		}
+		if err := askRunName(opts); err != nil {
+			return err
+		}
+	}
+
+	lr, err := log.NewReader(log.LogTypePipeline, opts)
+	if err != nil {
+		return err
+	}
+
+	logC, errC, err := lr.Read()
+	if err != nil {
+		return err
+	}
+
+	log.NewWriter(log.LogTypePipeline).Write(opts.Stream, logC, errC)
+
+	return nil
+}
+
+func askRunName(opts *options.LogOptions) error {
+	lOpts := metav1.ListOptions{}
+
+	// We are able to show much more than the default 5 with fzf, so let
+	// increase that limit limited to 100
+	if opts.Fzf && opts.Limit == defaultLimit {
+		opts.Limit = 100
+	}
+
+	prs, err := prhelper.GetAllPipelineRuns(opts.Params, lOpts, opts.Limit)
+	if err != nil {
+		return err
+	}
+
+	if len(prs) == 0 {
+		fmt.Fprint(os.Stdout, "No PipelineRuns found")
+		return nil
+	}
+
+	if len(prs) == 1 || opts.Last {
+		opts.PipelineRunName = strings.Fields(prs[0])[0]
+		return nil
+	}
+
+	if opts.Fzf {
+		return opts.FuzzyAsk(options.ResourceNamePipelineRun, prs)
+	}
+	return opts.Ask(options.ResourceNamePipelineRun, prs)
+}

--- a/vendor/github.com/tektoncd/cli/pkg/cmd/pipelinerun/pipelinerun.go
+++ b/vendor/github.com/tektoncd/cli/pkg/cmd/pipelinerun/pipelinerun.go
@@ -1,0 +1,47 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelinerun
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/flags"
+)
+
+// Command instantiates the pipelinerun command
+func Command(p cli.Params) *cobra.Command {
+	c := &cobra.Command{
+		Use:     "pipelinerun",
+		Aliases: []string{"pr", "pipelineruns"},
+		Short:   "Manage PipelineRuns",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return flags.InitParams(p, cmd)
+		},
+	}
+
+	flags.AddTektonOptions(c)
+	c.AddCommand(
+		describeCommand(p),
+		listCommand(p),
+		logCommand(p),
+		cancelCommand(p),
+		deleteCommand(p),
+	)
+
+	return c
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -631,6 +631,7 @@ github.com/subosito/gotenv
 github.com/tektoncd/cli/pkg/actions
 github.com/tektoncd/cli/pkg/cli
 github.com/tektoncd/cli/pkg/cmd/completion
+github.com/tektoncd/cli/pkg/cmd/pipelinerun
 github.com/tektoncd/cli/pkg/cmd/taskrun
 github.com/tektoncd/cli/pkg/deleter
 github.com/tektoncd/cli/pkg/file


### PR DESCRIPTION
This change introduces a new command group "run" that can be used to imperatively
invoke Tekton Task definitions.  The command `mink run task NAME` will fetch the
task definition, and dynamically create a new sub-command for the named task,
surfacing arguments via the normal cobra help test.

So for example, the following task definition:

```yaml
apiVersion: tekton.dev/v1beta1
kind: Task
metadata:
  name: hello
spec:
  description: "Says hello and stuff"
  params:
    - name: name
      description: The name of the person to greet.
    - name: greeting
      description: The greeting to use
      default: "Hello"

  results:
  - name: message
    description: The message that was printed

  steps:
    - name: echo
      image: ubuntu
      command:
        - /bin/bash
      args:
        - -c
        - echo "$(params.greeting), $(params.name)" | tee /tekton/results/message
```

Is translated into the following help text:

```shell
$ mink run task hello -- --help
Says hello and stuff

Usage:
  mink run task hello [flags]

Flags:
      --greeting string   The greeting to use (default "Hello")
  -h, --help              help for mink
      --name string       The name of the person to greet.
  -o, --output string     options: message
```

... and can be invoked supplying values for the arguments via the CLI (note the
`--` is required for the way we double-process arguments):

```shell
$ mink run task hello -- --name Bill
[echo] Hello, Bill

```

Results of the TaskRun execution can be projected to STDOUT to enable command
composition via `-oNAME`:
```shell
$ mink run task hello -- --name Bill -omessage
[echo] Hello, Bill

Hello, Bill
```