### PR TITLE
Start a constants package for defining param/result names.

### DIFF
--- a/cmd/extract-digest/main.go
+++ b/cmd/extract-digest/main.go
@@ -21,8 +21,10 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 
 	"github.com/BurntSushi/toml"
+	"github.com/mattmoor/mink/pkg/constants"
 )
 
 type image struct {
@@ -34,7 +36,7 @@ type report struct {
 	Image image `toml:"image"`
 }
 
-var output = flag.String("output", "/tekton/results/IMAGE-DIGEST", "Where to write the image digest from report.toml")
+var output = flag.String("output", path.Join("/tekton/results", constants.ImageDigestResult), "Where to write the image digest from report.toml")
 
 func main() {
 	flag.Parse()

--- a/pkg/builds/build.go
+++ b/pkg/builds/build.go
@@ -18,7 +18,6 @@ package builds
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -26,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/mattmoor/mink/pkg/constants"
 	"github.com/tektoncd/cli/pkg/cmd/pipelinerun"
 	"github.com/tektoncd/cli/pkg/cmd/taskrun"
 	"github.com/tektoncd/cli/pkg/options"
@@ -43,15 +43,15 @@ func Run(ctx context.Context, image string, tr *tknv1beta1.TaskRun, opt *options
 	}
 
 	for _, result := range tr.Status.TaskRunResults {
-		if result.Name != "IMAGE-DIGEST" {
+		if result.Name != constants.ImageDigestResult {
 			continue
 		}
 		value := strings.TrimSpace(result.Value)
 
-		// Extract the IMAGE-DIGEST result.
+		// Extract the constants.ImageDigestResult result.
 		return name.NewDigest(image + "@" + value)
 	}
-	return name.Digest{}, errors.New("taskrun did not produce an IMAGE-DIGEST result")
+	return name.Digest{}, fmt.Errorf("taskrun did not produce an %q result", constants.ImageDigestResult)
 }
 
 func streamLogs(ctx context.Context, opt *options.LogOptions) error {

--- a/pkg/builds/buildpacks/build.go
+++ b/pkg/builds/buildpacks/build.go
@@ -21,12 +21,14 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/mattmoor/mink/pkg/constants"
 	tknv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -130,7 +132,7 @@ func Build(ctx context.Context, source name.Reference, target name.Tag, opt Opti
 
 			TaskSpec: &tknv1beta1.TaskSpec{
 				Results: []tknv1beta1.TaskResult{{
-					Name: "IMAGE-DIGEST",
+					Name: constants.ImageDigestResult,
 				}},
 
 				Volumes: volumes,
@@ -250,7 +252,9 @@ func Build(ctx context.Context, source name.Reference, target name.Tag, opt Opti
 						Name:       "extract-digest",
 						Image:      ExtractDigestImage.String(),
 						WorkingDir: workspaceDirectory,
-						Args:       []string{"-output=/tekton/results/IMAGE-DIGEST"},
+						Args: []string{
+							"-output", path.Join("/tekton/results", constants.ImageDigestResult),
+						},
 					},
 				}},
 			},

--- a/pkg/builds/dockerfile/build.go
+++ b/pkg/builds/dockerfile/build.go
@@ -18,9 +18,11 @@ package dockerfile
 
 import (
 	"context"
+	"path"
 	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/mattmoor/mink/pkg/constants"
 	tknv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,7 +60,7 @@ func Build(ctx context.Context, source name.Reference, target name.Tag, opt Opti
 
 			TaskSpec: &tknv1beta1.TaskSpec{
 				Results: []tknv1beta1.TaskResult{{
-					Name: "IMAGE-DIGEST",
+					Name: constants.ImageDigestResult,
 				}},
 
 				Steps: []tknv1beta1.Step{{
@@ -84,7 +86,7 @@ func Build(ctx context.Context, source name.Reference, target name.Tag, opt Opti
 							"--destination=" + target.Name(),
 
 							// Write out the digest to the appropriate result file.
-							"--digest-file=/tekton/results/IMAGE-DIGEST",
+							"--digest-file", path.Join("/tekton/results", constants.ImageDigestResult),
 
 							// Enable kanikache to get incremental builds
 							"--cache=true",

--- a/pkg/builds/ko/build.go
+++ b/pkg/builds/ko/build.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/mattmoor/mink/pkg/constants"
 	tknv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -55,7 +56,7 @@ func Build(ctx context.Context, source name.Reference, target name.Tag, opt Opti
 
 			TaskSpec: &tknv1beta1.TaskSpec{
 				Results: []tknv1beta1.TaskResult{{
-					Name: "IMAGE-DIGEST",
+					Name: constants.ImageDigestResult,
 				}},
 
 				Steps: []tknv1beta1.Step{{
@@ -88,7 +89,7 @@ func Build(ctx context.Context, source name.Reference, target name.Tag, opt Opti
 								"export GOARM=$(go env GOARM)",
 								"export GOROOT=$(go env GOROOT)",
 								// Where the magic happens.
-								fmt.Sprintf("ko publish --bare %s | cut -d'@' -f 2 > /tekton/results/IMAGE-DIGEST", opt.ImportPath),
+								fmt.Sprintf("ko publish --bare %s | cut -d'@' -f 2 > /tekton/results/%s", opt.ImportPath, constants.ImageDigestResult),
 							}, " && "),
 						},
 						Resources: corev1.ResourceRequirements{

--- a/pkg/constants/depcheck_test.go
+++ b/pkg/constants/depcheck_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants_test
+
+import (
+	"testing"
+
+	"knative.dev/pkg/depcheck"
+)
+
+func TestNoDeps(t *testing.T) {
+	depcheck.AssertOnlyDependencies(t, map[string][]string{
+		"github.com/mattmoor/mink/pkg/constants": nil,
+	})
+}

--- a/pkg/constants/doc.go
+++ b/pkg/constants/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package constants defines a collection of constants for use throughout
+// mink.  It should have no dependencies.
+package constants

--- a/pkg/constants/params.go
+++ b/pkg/constants/params.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+const (
+// TODO(mattmoor): Add well-known parameter names here.
+)

--- a/pkg/constants/results.go
+++ b/pkg/constants/results.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+const (
+	// ImageDigestResult is the name of the Tekton result that is expected
+	// to surface the digest of a singular image produces by a given task
+	// or pipeline.  This digest is NOT fully qualified, so it should have
+	// the form: sha256:deadbeef   (shortened for brevity)
+	//
+	// Generally this input string is paired with a parameter that directs
+	// the task to publish the image to a particular tag, e.g.
+	//   ghcr.io/mattmoor/mink-images:latest
+	//
+	// So the fully qualified digest may be assembled by concatenating these
+	// with an @:
+	//   ghcr.io/mattmoor/mink-images:latest@sha256:deadbeef
+	ImageDigestResult = "mink-image-digest"
+)


### PR DESCRIPTION
This starts to encapsulate some of the parameter and result naming
conventions we will make use of to duck-type tasks and pipelines
into a common package that the various utilities may draw from.

These values are not (yet) set in stone, as I'm hopeful that we can
migrate them to use the reverse-DNS style (with some support in
Tekton), to better avoid collisions.

Related: https://github.com/tektoncd/pipeline/issues/3590