### PR TITLE
Refactor mink run to orient around a Processor abstraction.

### DIFF
--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -17,7 +17,19 @@ limitations under the License.
 package command
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/spf13/cobra"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/pkg/apis"
+)
+
+var (
+	specialParams = sets.NewString()
+
+	// specialResults = sets.NewString(constants.ImageDigestResult)
 )
 
 // NewRunCommand implements 'kn-im run' command
@@ -31,4 +43,126 @@ func NewRunCommand() *cobra.Command {
 	cmd.AddCommand(NewRunPipelineCommand())
 
 	return cmd
+}
+
+// Processor is an interface for augmenting a vanilla run execution with
+// additional pre/post functionality "mixed in".
+type Processor interface {
+	PreRun(params []v1beta1.ParamSpec) ([]v1beta1.Param, error)
+	PostRun(results []v1beta1.TaskRunResult) error
+}
+
+func p2tResults(prr []v1beta1.PipelineRunResult) []v1beta1.TaskRunResult {
+	trr := make([]v1beta1.TaskRunResult, 0, len(prr))
+	for _, res := range prr {
+		trr = append(trr, v1beta1.TaskRunResult(res))
+	}
+	return trr
+}
+
+// ProcessorFuncs is a helper for implementing Processor
+type ProcessorFuncs struct {
+	PreRunFunc  func([]v1beta1.ParamSpec) ([]v1beta1.Param, error)
+	PostRunFunc func([]v1beta1.TaskRunResult) error
+}
+
+var _ Processor = (*ProcessorFuncs)(nil)
+
+// PreRun implements Processor
+func (pf *ProcessorFuncs) PreRun(params []v1beta1.ParamSpec) ([]v1beta1.Param, error) {
+	if pf.PreRunFunc != nil {
+		return pf.PreRunFunc(params)
+	}
+	return nil, nil
+}
+
+// PostRun implements Processor
+func (pf *ProcessorFuncs) PostRun(results []v1beta1.TaskRunResult) error {
+	if pf.PostRunFunc != nil {
+		return pf.PostRunFunc(results)
+	}
+	return nil
+}
+
+func processParams(cmd *cobra.Command, params []v1beta1.ParamSpec) (Processor, error) {
+	for _, param := range params {
+		// Elide turning "special" parameters into arguments.
+		if specialParams.Has(param.Name) {
+			continue
+		}
+
+		switch param.Type {
+		case v1beta1.ParamTypeArray:
+			// TODO(mattmoor): Any magic for this?
+			// If all else fails: https://stackoverflow.com/questions/28322997/how-to-get-a-list-of-values-into-a-flag-in-golang
+			return nil, fmt.Errorf("unsupported parameter type array: %q", param.Name)
+		default:
+			if param.Default != nil {
+				cmd.Flags().String(param.Name, param.Default.StringVal, param.Description)
+			} else {
+				cmd.Flags().String(param.Name, "", param.Description)
+			}
+		}
+	}
+
+	return &ProcessorFuncs{
+		PreRunFunc: func(params []v1beta1.ParamSpec) ([]v1beta1.Param, error) {
+			ps := make([]v1beta1.Param, 0, len(params))
+			for _, param := range params {
+				// Elide turning "special" parameters into arguments.
+				if specialParams.Has(param.Name) {
+					continue
+				}
+
+				f := cmd.Flags().Lookup(param.Name)
+
+				if param.Default == nil && f.Value.String() == "" {
+					return nil, apis.ErrMissingField(param.Name)
+				}
+
+				ps = append(ps, v1beta1.Param{
+					Name:  param.Name,
+					Value: *v1beta1.NewArrayOrString(f.Value.String()),
+				})
+			}
+			return ps, nil
+		},
+	}, nil
+}
+
+func newResultProcessor(cmd *cobra.Command, results sets.String) Processor {
+	var result string
+
+	// TODO(mattmoor): Incorporate the output descriptions.
+	cmd.Flags().StringVarP(&result, "output", "o", "", "options: "+strings.Join(results.List(), ", "))
+	return &ProcessorFuncs{
+		PostRunFunc: func(results []v1beta1.TaskRunResult) error {
+			if result == "" {
+				return nil
+			}
+			for _, r := range results {
+				if r.Name != result {
+					continue
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "%s\n", strings.TrimSpace(r.Value))
+				return nil
+			}
+			return fmt.Errorf("unable to find result %q", result)
+		},
+	}
+}
+
+func detectProcessors(cmd *cobra.Command, params []v1beta1.ParamSpec, results sets.String) (processors []Processor, err error) {
+	if len(params) > 0 {
+		p, err := processParams(cmd, params)
+		if err != nil {
+			return nil, err
+		}
+		processors = append(processors, p)
+	}
+
+	if len(results) > 0 {
+		processors = append(processors, newResultProcessor(cmd, results))
+	}
+	return processors, nil
 }

--- a/pkg/command/run_task.go
+++ b/pkg/command/run_task.go
@@ -18,7 +18,6 @@ package command
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/mattmoor/mink/pkg/builds"
 	"github.com/spf13/cobra"
@@ -28,7 +27,7 @@ import (
 	tektonclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/signals"
 )
 
@@ -117,10 +116,7 @@ func (opts *RunTaskOptions) Execute(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// The (optional) name of the "result" to output to STDOUT.
-	// TODO(mattmoor): Task/Pipeline don't share a type, which makes
-	// sharing the result logic harder than it should be.
-	var result *string
+	var processors []Processor
 
 	taskCmd := &cobra.Command{
 		Use:   "mink run task " + task.Name,
@@ -132,24 +128,18 @@ func (opts *RunTaskOptions) Execute(cmd *cobra.Command, args []string) error {
 					GenerateName: "mink-" + task.Name + "-",
 				},
 				Spec: v1beta1.TaskRunSpec{
-					Params: make([]v1beta1.Param, 0, len(task.Spec.Params)),
 					TaskRef: &v1beta1.TaskRef{
 						Name: task.Name,
 					},
 				},
 			}
 
-			for _, param := range task.Spec.Params {
-				f := cmd.Flags().Lookup(param.Name)
-
-				if param.Default == nil && f.Value.String() == "" {
-					return apis.ErrMissingField(param.Name)
+			for _, processor := range processors {
+				ps, err := processor.PreRun(task.Spec.Params)
+				if err != nil {
+					return err
 				}
-
-				tr.Spec.Params = append(tr.Spec.Params, v1beta1.Param{
-					Name:  param.Name,
-					Value: *v1beta1.NewArrayOrString(f.Value.String()),
-				})
+				tr.Spec.Params = append(tr.Spec.Params, ps...)
 			}
 
 			tr, err := builds.RunTask(ctx, tr, &options.LogOptions{
@@ -160,51 +150,30 @@ func (opts *RunTaskOptions) Execute(cmd *cobra.Command, args []string) error {
 					Err: cmd.OutOrStderr(),
 				},
 				Follow: true,
-			}, builds.WithTaskServiceAccount(opts.ServiceAccount))
+			}) //, builds.WithTaskServiceAccount(opts.ServiceAccount))
 			if err != nil {
 				return err
 			}
 
-			// If running the task succeeded, then handle formatting the results as output.
-			if result != nil {
-				for _, r := range tr.Status.TaskRunResults {
-					if r.Name != *result {
-						continue
-					}
-					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", strings.TrimSpace(r.Value))
+			for _, processor := range processors {
+				if err := processor.PostRun(tr.Status.TaskRunResults); err != nil {
+					return err
 				}
 			}
 			return nil
 		},
 	}
 
-	for _, param := range task.Spec.Params {
-		switch param.Type {
-		case v1beta1.ParamTypeArray:
-			// TODO(mattmoor): Any magic for this?
-			// If all else fails: https://stackoverflow.com/questions/28322997/how-to-get-a-list-of-values-into-a-flag-in-golang
-			return fmt.Errorf("unsupported parameter type array: %q", param.Name)
-		default:
-			// TODO(mattmoor): Look for arguments with a particular name, to signal the bundle logic.
-
-			if param.Default != nil {
-				taskCmd.Flags().String(param.Name, param.Default.StringVal, param.Description)
-			} else {
-				taskCmd.Flags().String(param.Name, "", param.Description)
-			}
-		}
+	// Process the results of the task.
+	results := make(sets.String, len(task.Spec.Results))
+	for _, result := range task.Spec.Results {
+		results.Insert(result.Name)
 	}
 
-	if len(task.Spec.Results) > 0 {
-		result = new(string)
-
-		// TODO(mattmoor): Validate supported "options" values.
-		options := make([]string, 0, len(task.Spec.Results))
-		for _, result := range task.Spec.Results {
-			options = append(options, result.Name)
-		}
-		// TODO(mattmoor): Incorporate the output descriptions.
-		taskCmd.Flags().StringVarP(result, "output", "o", "", "options: "+strings.Join(options, ", "))
+	// Based on the signature determine which processors to wire in.
+	processors, err = detectProcessors(taskCmd, task.Spec.Params, results)
+	if err != nil {
+		return err
 	}
 
 	taskCmd.SetArgs(args[1:])


### PR DESCRIPTION
This moves much of the parameter and result handling into shared Processors, but this restructuring was ultimately aimed at facilitating the duck-typed processing capabilities I'm hoping to start experimenting with.