### PR TITLE
Support passing source bundle to mink run.

### DIFF
--- a/.github/workflows/minkind-run.yaml
+++ b/.github/workflows/minkind-run.yaml
@@ -80,16 +80,20 @@ jobs:
             ${KO_DOCKER_REPO}/{{ lower (join "buildpack-images" .Host .Path) }}
           {{ else if eq .Scheme "dockerfile" }}
             ${KO_DOCKER_REPO}/{{ lower (join "dockerfile-images" .Host .Path) }}
+          {{ else if eq .Scheme "task" }}
+            ${KO_DOCKER_REPO}/{{ lower (join "task-images" .Host .Path) }}
+          {{ else if eq .Scheme "pipeline" }}
+            ${KO_DOCKER_REPO}/{{ lower (join "pipeline-images" .Host .Path) }}
           {{ else }}
             BREAK THINGS
           {{ end }}
         EOF
 
-    - name: Test mink run task
+    - name: "Smoke Test: mink run task"
       working-directory: ./src/github.com/mattmoor/mink
       run: |
         # Apply the sample task definition.
-        kubectl apply -f examples/task-hello.yaml
+        kubectl apply -f examples/task-hello.yaml -f examples/task-bundle.yaml -f examples/task-image.yaml
 
         NAME=${RANDOM}
 
@@ -113,11 +117,33 @@ jobs:
         fi
         echo '::endgroup::'
 
-    - name: Test mink run pipeline
+        echo '::group:: Test w/ bundle'
+        WANT="${RANDOM}"
+        echo ${WANT} > the-file-name
+        GOT=$(mink run task hello-bundles -- --the-file the-file-name -ocontents)
+
+        if [[ "${GOT}" != "${WANT}" ]]; then
+          echo Got: ${GOT}, wanted ${WANT},
+          exit 1
+        fi
+        rm the-file-name
+        echo '::endgroup::'
+
+        echo '::group:: Test w/ image'
+        WANT="${KO_DOCKER_REPO}/task-images"
+        GOT=$(mink run task hello-image -- -oimage)
+
+        if [[ "${GOT}" != "${WANT}" ]]; then
+          echo Got: ${GOT}, wanted ${WANT},
+          exit 1
+        fi
+        echo '::endgroup::'
+
+    - name: "Smoke Test: mink run pipeline"
       working-directory: ./src/github.com/mattmoor/mink
       run: |
         # Apply the sample task definition.
-        kubectl apply -f examples/pipeline-hello.yaml
+        kubectl apply -f examples/pipeline-hello.yaml -f examples/pipeline-bundle.yaml -f examples/pipeline-image.yaml
 
         NAME=${RANDOM}
 
@@ -139,6 +165,37 @@ jobs:
           echo Got: ${GOT}, wanted ${WANT},
           exit 1
         fi
+        echo '::endgroup::'
+
+        echo '::group:: Test w/ bundle'
+        echo ${RANDOM} > the-file-name
+        WANT="Hello, $(cat the-file-name)"
+        GOT=$(mink run pipeline hello-bundles -- --the-file the-file-name -omessage)
+
+        if [[ "${GOT}" != "${WANT}" ]]; then
+          echo Got: ${GOT}, wanted ${WANT},
+          exit 1
+        fi
+        rm the-file-name
+        echo '::endgroup::'
+
+        echo '::group:: Test w/ image'
+        WANT="Hello, ${KO_DOCKER_REPO}/pipeline-images"
+        GOT=$(mink run pipeline hello-image -- -omessage)
+
+        if [[ "${GOT}" != "${WANT}" ]]; then
+          echo Got: ${GOT}, wanted ${WANT},
+          exit 1
+        fi
+        echo '::endgroup::'
+
+    - name: "e2e Test: mink run task"
+      working-directory: ./src/github.com/mattmoor/mink
+      run: |
+        kubectl apply -f examples/kaniko.yaml
+
+        echo '::group:: Build kuard'
+        mink run task kaniko --git-url=https://github.com/kubernetes-up-and-running/kuard.git
         echo '::endgroup::'
 
     - name: Collect system diagnostics

--- a/examples/kaniko.yaml
+++ b/examples/kaniko.yaml
@@ -1,0 +1,37 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kaniko
+spec:
+  description: "An example kaniko task illustrating some of the parameter processing."
+  params:
+    - name: mink-source-bundle
+      description: A self-extracting container image of source
+    - name: mink-image-target
+      description: Where to publish an image.
+    - name: dockerfile
+      description: The path to the dockerfile.
+      default: Dockerfile
+
+  results:
+    - name: mink-image-digest
+      description: The digest of the resulting image.
+
+  steps:
+    - name: extract-bundle
+      image: $(params.mink-source-bundle)
+      workingDir: /workspace
+
+    - name: build-and-push
+      image: gcr.io/kaniko-project/executor:multi-arch
+      env:
+      - name: DOCKER_CONFIG
+        value: /tekton/home/.docker
+      args:
+      - --dockerfile=/workspace/$(params.dockerfile)
+      - --context=/workspace
+      - --destination=$(params.mink-image-target)
+      - --digest-file=/tekton/results/$(results.mink-image-digest)
+      - --cache=true
+      - --cache-ttl=24h
+      # TODO(mattmoor): KanikoArgs

--- a/examples/pipeline-bundle.yaml
+++ b/examples/pipeline-bundle.yaml
@@ -1,0 +1,36 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: hello-bundles
+spec:
+  description: "Enumerates the uploaded files."
+  params:
+    - name: mink-source-bundle
+      description: A self-extracting container image.
+      default: docker.io/tianon/true
+    - name: the-file
+      description: The name of the file to cat
+
+  results:
+  - name: message
+    description: The final message
+    value: $(tasks.greet-it.results.message)
+
+  tasks:
+    - name: dump-file
+      taskRef:
+        name: hello-bundles
+      params:
+        - name: mink-source-bundle
+          value: "$(params.mink-source-bundle)"
+        - name: the-file
+          value: "$(params.the-file)"
+
+    - name: greet-it
+      runAfter:
+      - dump-file
+      taskRef:
+        name: hello
+      params:
+        - name: name
+          value: "$(tasks.dump-file.results.contents)"

--- a/examples/pipeline-image.yaml
+++ b/examples/pipeline-image.yaml
@@ -1,0 +1,31 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: hello-image
+spec:
+  description: "Enumerates the uploaded files."
+  params:
+    - name: mink-image-target
+      description: Typically where to publish an image.
+
+  results:
+  - name: message
+    description: The final message
+    value: $(tasks.greet-it.results.message)
+
+  tasks:
+    - name: echo-image
+      taskRef:
+        name: hello-image
+      params:
+        - name: mink-image-target
+          value: "$(params.mink-image-target)"
+
+    - name: greet-it
+      runAfter:
+      - echo-image
+      taskRef:
+        name: hello
+      params:
+        - name: name
+          value: "$(tasks.echo-image.results.image)"

--- a/examples/task-bundle.yaml
+++ b/examples/task-bundle.yaml
@@ -1,0 +1,29 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: hello-bundles
+spec:
+  description: "Enumerates the uploaded files."
+  params:
+    - name: mink-source-bundle
+      description: A self-extracting container image.
+      default: docker.io/tianon/true
+    - name: the-file
+      description: The name of the file to cat
+
+  results:
+    - name: contents
+      description: The contents of one of an uploaded file.
+
+  steps:
+    - name: extract-bundle
+      image: $(params.mink-source-bundle)
+
+    - name: echo
+      image: ubuntu
+      command:
+        - /bin/bash
+      args:
+        - -c
+        - |
+          cat $(params.the-file) > /tekton/results/contents

--- a/examples/task-image.yaml
+++ b/examples/task-image.yaml
@@ -1,0 +1,23 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: hello-image
+spec:
+  description: "Echo back the image parameter."
+  params:
+    - name: mink-image-target
+      description: Typically where to publish an image.
+
+  results:
+    - name: image
+      description: The image tag we have been instructed to target.
+
+  steps:
+    - name: echo
+      image: ubuntu
+      command:
+        - /bin/bash
+      args:
+        - -c
+        - |
+          echo $(params.mink-image-target) > /tekton/results/image

--- a/pkg/builds/dockerfile/build.go
+++ b/pkg/builds/dockerfile/build.go
@@ -39,9 +39,6 @@ type Options struct {
 	// Dockerfile is the path to the Dockerfile within the build context.
 	Dockerfile string
 
-	// The path within the build context in which to execute the build.
-	Path string
-
 	// The extra kaniko arguments for handling things like insecure registries
 	KanikoArgs []string
 }
@@ -78,11 +75,11 @@ func Build(ctx context.Context, source name.Reference, target name.Tag, opt Opti
 							Value: "/tekton/home/.docker",
 						}},
 						Args: append([]string{
-							"--dockerfile=" + filepath.Join("/workspace", opt.Path, opt.Dockerfile),
+							"--dockerfile=" + filepath.Join("/workspace", opt.Dockerfile),
 
 							// We expand into /workspace, and publish to the specified
 							// output resource image.
-							"--context=" + filepath.Join("/workspace", opt.Path),
+							"--context=/workspace",
 							"--destination=" + target.Name(),
 
 							// Write out the digest to the appropriate result file.

--- a/pkg/command/run_pipeline.go
+++ b/pkg/command/run_pipeline.go
@@ -39,7 +39,11 @@ var runPipelineExample = fmt.Sprintf(`
 
 // NewRunPipelineCommand implements 'kn-im run pipeline' command
 func NewRunPipelineCommand() *cobra.Command {
-	opts := &RunPipelineOptions{}
+	opts := &RunPipelineOptions{
+		RunOptions: RunOptions{
+			resource: "pipeline",
+		},
+	}
 
 	cmd := &cobra.Command{
 		Use:          "pipeline NAME",
@@ -69,8 +73,8 @@ func NewRunPipelineCommand() *cobra.Command {
 
 // RunPipelineOptions implements Interface for the `kn im run pipeline` command.
 type RunPipelineOptions struct {
-	// Inherit all of the base build options.
-	BaseBuildOptions
+	// Inherit all of the base run options.
+	RunOptions
 }
 
 // RunPipelineOptions implements Interface
@@ -150,7 +154,7 @@ func (opts *RunPipelineOptions) Execute(cmd *cobra.Command, args []string) error
 					Err: cmd.OutOrStderr(),
 				},
 				Follow: true,
-			}) //, builds.WithPipelineServiceAccount(opts.ServiceAccount))
+			}, builds.WithPipelineServiceAccount(opts.ServiceAccount, opts.references...))
 			if err != nil {
 				return err
 			}
@@ -172,7 +176,7 @@ func (opts *RunPipelineOptions) Execute(cmd *cobra.Command, args []string) error
 	}
 
 	// Based on the signature determine which processors to wire in.
-	processors, err = detectProcessors(pipelineCmd, pipeline.Spec.Params, results)
+	processors, err = opts.detectProcessors(pipelineCmd, pipeline.Spec.Params, results)
 	if err != nil {
 		return err
 	}

--- a/pkg/command/run_task.go
+++ b/pkg/command/run_task.go
@@ -39,7 +39,11 @@ var runTaskExample = fmt.Sprintf(`
 
 // NewRunTaskCommand implements 'kn-im run task' command
 func NewRunTaskCommand() *cobra.Command {
-	opts := &RunTaskOptions{}
+	opts := &RunTaskOptions{
+		RunOptions: RunOptions{
+			resource: "task",
+		},
+	}
 
 	cmd := &cobra.Command{
 		Use:          "task NAME",
@@ -69,8 +73,8 @@ func NewRunTaskCommand() *cobra.Command {
 
 // RunTaskOptions implements Interface for the `kn im run task` command.
 type RunTaskOptions struct {
-	// Inherit all of the base build options.
-	BaseBuildOptions
+	// Inherit all of the base run options.
+	RunOptions
 }
 
 // RunTaskOptions implements Interface
@@ -150,7 +154,7 @@ func (opts *RunTaskOptions) Execute(cmd *cobra.Command, args []string) error {
 					Err: cmd.OutOrStderr(),
 				},
 				Follow: true,
-			}) //, builds.WithTaskServiceAccount(opts.ServiceAccount))
+			}, builds.WithTaskServiceAccount(opts.ServiceAccount, opts.references...))
 			if err != nil {
 				return err
 			}
@@ -171,7 +175,7 @@ func (opts *RunTaskOptions) Execute(cmd *cobra.Command, args []string) error {
 	}
 
 	// Based on the signature determine which processors to wire in.
-	processors, err = detectProcessors(taskCmd, task.Spec.Params, results)
+	processors, err = opts.detectProcessors(taskCmd, task.Spec.Params, results)
 	if err != nil {
 		return err
 	}

--- a/pkg/constants/params.go
+++ b/pkg/constants/params.go
@@ -17,5 +17,14 @@ limitations under the License.
 package constants
 
 const (
-// TODO(mattmoor): Add well-known parameter names here.
+	// SourceBundleParam is the name of the Tekton parameter that is
+	// expected to pass the fully-qualified URI of a container image that
+	// when run unpacks its payload into the working directory in which
+	// it was invoked.
+	SourceBundleParam = "mink-source-bundle"
+
+	// ImageTargetParam is the name of the Tekton parameter that is
+	// expected to pass the fully-qualified URI for where to publish
+	// a container image.
+	ImageTargetParam = "mink-image-target"
 )


### PR DESCRIPTION
This adds support for lighting up two pieces of functionality:
1. Recognizing when a source bundle is required, creating one and passing it through to the FooRun.
2. Recognizing when a the task or pipeline uploads an image, and passing through the image to which the FooRun should upload the image.

In addition to the signature matching and mechanical logic this plumbs through support for `--as=me` for pipelines, and outlined tasks, which previously did not work because of the assumption the inline TaskSpec could simply be rewritten.

Fixes: https://github.com/mattmoor/mink/issues/317