### PR TITLE
Add logic to emit the fully-qualified digest from `mink run`.

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -117,5 +117,6 @@ For examples of how to use this functionality see
 
 #### `mink-image-digest`
 
-This does not yet activate any special functionality in `mink run`, but is the
-result name used in `mink build` and friends.
+When this result is present, along with the `mink-image-target` parameter the
+`mink run` will by default emit the `{tag}@{digest}` combination when the
+execution is complete.

--- a/examples/kaniko.yaml
+++ b/examples/kaniko.yaml
@@ -31,7 +31,7 @@ spec:
       - --dockerfile=/workspace/$(params.dockerfile)
       - --context=/workspace
       - --destination=$(params.mink-image-target)
-      - --digest-file=/tekton/results/$(results.mink-image-digest)
+      - --digest-file=/tekton/results/mink-image-digest
       - --cache=true
       - --cache-ttl=24h
       # TODO(mattmoor): KanikoArgs


### PR DESCRIPTION
When the tag parameter and digest result are present, emit the fully-qualified digest by default to enable composition with commands like `kn service create --image=...`.