### PR TITLE
Share the definition of the kaniko task.

### DIFF
--- a/cmd/example-gen/main.go
+++ b/cmd/example-gen/main.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+
+	"github.com/mattmoor/mink/pkg/builds/dockerfile"
+)
+
+var where = flag.String("where", "./examples", "The directory into which we should write examples.")
+
+const generatedHeader = "# DO NOT EDIT THIS IS A GENERATED FILE (see ./hack/update-codegen.sh)\n\n"
+
+func main() {
+	flag.Parse()
+
+	outputs := map[string]string{
+		"kaniko.yaml": dockerfile.KanikoTaskString,
+	}
+
+	for k, v := range outputs {
+		if err := ioutil.WriteFile(filepath.Join(*where, k), []byte(generatedHeader+v), 0600); err != nil {
+			log.Fatalf("Error writing %q: %v", k, err)
+		}
+	}
+}

--- a/examples/kaniko.yaml
+++ b/examples/kaniko.yaml
@@ -1,3 +1,6 @@
+# DO NOT EDIT THIS IS A GENERATED FILE (see ./hack/update-codegen.sh)
+
+
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
@@ -15,6 +18,10 @@ spec:
     - name: dockerfile
       description: The name of the dockerfile.
       default: Dockerfile
+    - name: kaniko-args
+      description: Extra arguments to supply to kaniko
+      type: array
+      default: []
 
   results:
     - name: mink-image-digest
@@ -37,4 +44,4 @@ spec:
       - --digest-file=/tekton/results/mink-image-digest
       - --cache=true
       - --cache-ttl=24h
-      # TODO(mattmoor): KanikoArgs
+      - $(params.kaniko-args)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher v0.0.0-20191203181535-308b93ad1f39
 	github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960
 	github.com/emicklei/go-restful v2.11.1+incompatible // indirect
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.3.0 // indirect
 	github.com/google/go-containerregistry v0.1.4
 	github.com/google/ko v0.6.0

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 REPO_ROOT=$(dirname ${BASH_SOURCE})/..
 
-# TODO(mattmoor): Do fun things with config/
+go run ./cmd/example-gen/main.go -where ${REPO_ROOT}/examples
 
 # Make sure our dependencies are up-to-date
 ${REPO_ROOT}/hack/update-deps.sh

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -290,6 +290,7 @@ github.com/gdamore/tcell/terminfo/v/vt102
 github.com/gdamore/tcell/terminfo/v/vt220
 github.com/gdamore/tcell/terminfo/x/xterm
 # github.com/ghodss/yaml v1.0.0
+## explicit
 github.com/ghodss/yaml
 # github.com/go-logr/logr v0.3.0
 ## explicit


### PR DESCRIPTION
This reworks how we define the kaniko task(s) to use a shared definition.  The yaml is now inlined and parsed to produce the TaskSpec used in `mink build`.  The example yaml is now produced from this as part of `./hack/update-codegen.sh`.