### PR TITLE
Drop the concept of `overrides.toml`

### DIFF
--- a/APPLY.md
+++ b/APPLY.md
@@ -13,7 +13,7 @@ Suppose my repository is laid out like:
     main.go
   baz/
     main.ru
-    overrides.toml
+    project.toml
   config/
     lots-of.yaml
 ```
@@ -82,22 +82,19 @@ mink build --dockerfile=a/b/c/Dockerfile
 #### `buildpack:///` semantics
 
 `buildpack:///a/b/c` will trigger a buildpack build within the uploaded context
-with a set of optional overrides to `project.toml` supplied via
-`a/b/c/overrides.toml`. If `--overrides=blah.toml` is passed then the build will
-use `a/b/c/blah.toml` for the overrides. There is not currently a way to scope
-the build context differently or supply different `--overrides` per build
+with the project descriptor (aka `project.toml`) loaded via
+`a/b/c/project.toml`. If `--descriptor=blah.toml` is passed then the build will
+use `a/b/c/blah.toml` for the project descriptor. There is not currently a way to scope
+the build context differently or supply different `--descriptor` per build
 target.
 
 This build may be reproduced with:
 
 ```shell
-mink buildpack --overrides=a/b/c/blah.toml
+mink buildpack --descriptor=a/b/c/blah.toml
 ```
 
-> **NOTE:** `overrides.toml` is a `mink`-specific concept that builds around the
-> buildpack construct of `project.toml`, **it is not portable**.
-
-Example using `overrides.toml` to select the Go package to build:
+Example using `project.toml` to select the Go package to build:
 
 ```toml
 [[build.env]]
@@ -105,7 +102,7 @@ name = "BP_GO_TARGETS"
 value = "./cmd/foo"
 ```
 
-Example using `overrides.toml` to specify the GCP function to target:
+Example using `project.toml` to specify the GCP function to target:
 
 ```toml
 [[build.env]]
@@ -190,7 +187,7 @@ Suppose we have complex directory structure:
           main.go
       baz/
         main.ru
-	overrides.toml
+	project.toml
     config/
       lots-of.yaml
 ```
@@ -207,7 +204,7 @@ then the bundle uploaded will contain:
       main.go
   baz/
     main.ru
-    overrides.toml
+    project.toml
 ```
 
 So the config references should take this into account and use:

--- a/buildpackerize.sh
+++ b/buildpackerize.sh
@@ -24,14 +24,14 @@ for x in $(find config -type f -name '*.yaml' | xargs grep "ko://" | sed 's@.*ko
   mkdir -p generated/buildpacks/$x
 
   if [[ "$x" =~ "github.com/mattmoor/mink" ]]; then
-    cat > generated/buildpacks/$x/overrides.toml <<EOF
+    cat > generated/buildpacks/$x/project.toml <<EOF
 [[build.env]]
 name = "BP_GO_TARGETS"
 value = "$(echo $x | sed 's@^github.com/mattmoor/mink/@./@g')"
 
 EOF
   else
-    cat > generated/buildpacks/$x/overrides.toml <<EOF
+    cat > generated/buildpacks/$x/project.toml <<EOF
 [[build.env]]
 name = "BP_GO_TARGETS"
 value = "$(echo $x | sed 's@^@./vendor/@g')"

--- a/cmd/platform-setup/main.go
+++ b/cmd/platform-setup/main.go
@@ -61,7 +61,7 @@ func handleTOML(filename string) {
 }
 
 var (
-	overrides = pflag.String("overrides", "", "The path to a set of overrides for project.toml")
+	descriptor = pflag.String("descriptor", "project.toml", "The path the project descriptor (aka project.toml)")
 )
 
 func main() {
@@ -70,10 +70,5 @@ func main() {
 	if err := os.MkdirAll(platformDir, os.ModePerm); err != nil {
 		log.Fatalf("Unable to create %q: %v", platformDir, err)
 	}
-
-	handleTOML("./project.toml")
-
-	if *overrides != "" {
-		handleTOML(*overrides)
-	}
+	handleTOML(*descriptor)
 }

--- a/examples/buildpack.yaml
+++ b/examples/buildpack.yaml
@@ -70,7 +70,7 @@ spec:
     - name: platform-setup
       image: ko://github.com/mattmoor/mink/cmd/platform-setup
       workingDir: /workspace
-      args: ["--overrides=/workspace/$(params.descriptor)"]
+      args: ["--descriptor=/workspace/$(params.descriptor)"]
       volumeMounts: *mounts
 
     - name: create

--- a/pkg/builds/buildpacks/build.go
+++ b/pkg/builds/buildpacks/build.go
@@ -128,7 +128,7 @@ spec:
     - name: platform-setup
       image: ko://github.com/mattmoor/mink/cmd/platform-setup
       workingDir: /workspace
-      args: ["--overrides=/workspace/$(params.descriptor)"]
+      args: ["--descriptor=/workspace/$(params.descriptor)"]
       volumeMounts: *mounts
 
     - name: create
@@ -191,8 +191,8 @@ type Options struct {
 	// Builder is the name of the builder image for which to apply the buildpack lifecycle.
 	Builder string
 
-	// OverrideFile is the name of the override.toml file (under Path)
-	OverrideFile string
+	// DescriptorFile holds the name of the project descriptor file (aka project.toml).
+	DescriptorFile string
 }
 
 // Build synthesizes a TaskRun definition that evaluates the buildpack lifecycle with the
@@ -218,7 +218,7 @@ func Build(ctx context.Context, source name.Reference, target name.Tag, opt Opti
 				Value: *tknv1beta1.NewArrayOrString(opt.Builder),
 			}, {
 				Name:  "descriptor",
-				Value: *tknv1beta1.NewArrayOrString(opt.OverrideFile),
+				Value: *tknv1beta1.NewArrayOrString(opt.DescriptorFile),
 			}},
 
 			TaskSpec: &BuildpackTask.Spec,

--- a/pkg/command/buildpacks.go
+++ b/pkg/command/buildpacks.go
@@ -76,8 +76,8 @@ type buildpackOptions struct {
 	// Builder is the name of the buildpack builder container image.
 	Builder string
 
-	// OverrideFile holds the name of the file that overrides project.toml settings.
-	OverrideFile string
+	// DescriptorFile holds the name of the project descriptor file (aka project.toml).
+	DescriptorFile string
 }
 
 // AddFlags implements Interface
@@ -85,8 +85,8 @@ func (opts *buildpackOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().String("builder", buildpacks.BuildpackImage,
 		"The name of the builder container image to execute.")
 
-	cmd.Flags().String("overrides", "overrides.toml",
-		"The name of the file to read project.toml overrides from.")
+	cmd.Flags().String("descriptor", "project.toml",
+		"The file from which to read the project descriptor (aka project.toml).")
 }
 
 // Validate implements Interface
@@ -96,9 +96,9 @@ func (opts *buildpackOptions) Validate(cmd *cobra.Command, args []string) error 
 		return minkcli.ErrMissingFlag("builder")
 	}
 
-	opts.OverrideFile = viper.GetString("overrides")
-	if opts.OverrideFile == "" {
-		return minkcli.ErrMissingFlag("overrides")
+	opts.DescriptorFile = viper.GetString("descriptor")
+	if opts.DescriptorFile == "" {
+		return minkcli.ErrMissingFlag("descriptor")
 	}
 	return nil
 }
@@ -160,7 +160,7 @@ func (opts *BuildpackOptions) build(ctx context.Context, sourceDigest name.Diges
 	tag, err := opts.tag(imageNameContext{
 		URL: url.URL{
 			Scheme: "buildpack",
-			Path:   filepath.Clean(filepath.Dir(opts.OverrideFile)),
+			Path:   filepath.Clean(filepath.Dir(opts.DescriptorFile)),
 		},
 	})
 	if err != nil {
@@ -169,8 +169,8 @@ func (opts *BuildpackOptions) build(ctx context.Context, sourceDigest name.Diges
 
 	// Create a Build definition for turning the source into an image via CNCF Buildpacks.
 	tr := buildpacks.Build(ctx, sourceDigest, tag, buildpacks.Options{
-		Builder:      opts.Builder,
-		OverrideFile: opts.OverrideFile,
+		Builder:        opts.Builder,
+		DescriptorFile: opts.DescriptorFile,
 	})
 	tr.Namespace = Namespace()
 

--- a/pkg/command/resolve.go
+++ b/pkg/command/resolve.go
@@ -380,7 +380,7 @@ func (opts *ResolveOptions) bp(ctx context.Context, source name.Digest, u *url.U
 		BaseBuildOptions: opts.BaseBuildOptions,
 		buildpackOptions: opts.buildpackOptions,
 	}
-	bpo.OverrideFile = filepath.Join(u.Path, opts.OverrideFile)
+	bpo.DescriptorFile = filepath.Join(u.Path, opts.DescriptorFile)
 
 	// Buffer the output, so we can display it on failures.
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
This drops the concept of `overrides.toml` from `mink`, opting instead to align around `project.toml` files for each target.  The main difference is that there isn't a way to practically share configuration across targets, but `mv foo/override.toml foo/project.toml` and  `cat project.toml >> foo/project.toml` will generally be enough to migrate to the new model.

This improves the compat story with `pack build`, which supports a `--descriptor` flag.

Fixes: https://github.com/mattmoor/mink/issues/359