### PR TITLE
increase test timeout from 40->50min

### DIFF
--- a/.github/workflows/minkind.yaml
+++ b/.github/workflows/minkind.yaml
@@ -179,7 +179,7 @@ jobs:
         set -x
 
         # Run the tests tagged as e2e on the KinD cluster.
-        go test -race -count=1 -timeout=40m -tags=e2e \
+        go test -race -count=1 -timeout=50m -tags=e2e \
            ${{ matrix.extra-go-flags }} ${{ matrix.test-suite }} \
            ${{ matrix.extra-test-flags }}
 


### PR DESCRIPTION
As we saw in eventing, for some reason tests seem to take longer with 1.20 and there's been some timeouts in the tests.

https://github.com/knative/eventing/pull/4729/files#diff-8d196c4ce9b53dec57fab83c31e0f2a460d671683b19c3ef3d662003e1305d1cR185

Here at least seems like the 40 minutes was exceeded also:
```
panic: test timed out after 40m0s

goroutine 39850 [running]:
testing.(*M).startAlarm.func1()
	/opt/hostedtoolcache/go/1.15.6/x64/src/testing/testing.go:1618 +0x11f
created by time.goFunc
	/opt/hostedtoolcache/go/1.15.6/x64/src/time/sleep.go:167 +0x52
```

https://github.com/mattmoor/mink/runs/1716380168?check_suite_focus=true

And looking at a few successful runs, the e2e eventing tests do hover around 40 minutes already:
https://github.com/mattmoor/mink/runs/1717176852?check_suite_focus=true