### PR TITLE
fix: better kaniko context handling

### DIFF
--- a/examples/kaniko.yaml
+++ b/examples/kaniko.yaml
@@ -15,6 +15,9 @@ spec:
     - name: path
       description: The path to the dockerfile.
       default: .
+    - name: context
+      description: The docker context relative to /workspace.
+      default: ""
     - name: dockerfile
       description: The name of the dockerfile.
       default: Dockerfile
@@ -42,7 +45,7 @@ spec:
         value: /tekton/home/.docker
       args:
       - --dockerfile=/workspace/$(params.path)/$(params.dockerfile)
-      - --context=/workspace
+      - --context=/workspace/$(params.context)
       - --destination=$(params.mink-image-target)
       - --digest-file=/tekton/results/mink-image-digest
       - --cache=true

--- a/pkg/builds/dockerfile/build_test.go
+++ b/pkg/builds/dockerfile/build_test.go
@@ -1,0 +1,63 @@
+package dockerfile
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRemoveKanikoContext(t *testing.T) {
+	testCases := []struct {
+		args          []string
+		expectedValue string
+		expectedArgs  []string
+	}{
+		{
+			args:          []string{"dummy", "argument"},
+			expectedValue: "",
+			expectedArgs:  []string{"dummy", "argument"},
+		},
+		{
+			args:          []string{"--context", "myctx", "dummy", "argument"},
+			expectedValue: "myctx",
+			expectedArgs:  []string{"dummy", "argument"},
+		},
+		{
+			args:          []string{"dummy", "--context", "myctx", "argument"},
+			expectedValue: "myctx",
+			expectedArgs:  []string{"dummy", "argument"},
+		},
+		{
+			args:          []string{"dummy", "argument", "--context", "myctx"},
+			expectedValue: "myctx",
+			expectedArgs:  []string{"dummy", "argument"},
+		},
+		{
+			args:          []string{"--context=myctx", "dummy", "argument"},
+			expectedValue: "myctx",
+			expectedArgs:  []string{"dummy", "argument"},
+		},
+		{
+			args:          []string{"dummy", "--context=myctx", "argument"},
+			expectedValue: "myctx",
+			expectedArgs:  []string{"dummy", "argument"},
+		},
+		{
+			args:          []string{"dummy", "argument", "--context=myctx"},
+			expectedValue: "myctx",
+			expectedArgs:  []string{"dummy", "argument"},
+		},
+	}
+
+	name := "context"
+	for _, tc := range testCases {
+		value, args := RemoveArgument(tc.args, name)
+
+		if value != tc.expectedValue {
+			t.Errorf("got value %s expected %s\n", value, tc.expectedValue)
+		}
+
+		if !reflect.DeepEqual(args, tc.expectedArgs) {
+			t.Errorf("resulting arguments %v expected %v\n", args, tc.expectedArgs)
+		}
+	}
+}

--- a/pkg/builds/dockerfile/build_test.go
+++ b/pkg/builds/dockerfile/build_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dockerfile
 
 import (
@@ -12,39 +28,39 @@ func TestRemoveKanikoContext(t *testing.T) {
 		expectedArgs  []string
 	}{
 		{
-			args:          []string{"dummy", "argument"},
+			args:          []string{"sample", "argument"},
 			expectedValue: "",
-			expectedArgs:  []string{"dummy", "argument"},
+			expectedArgs:  []string{"sample", "argument"},
 		},
 		{
-			args:          []string{"--context", "myctx", "dummy", "argument"},
+			args:          []string{"--context", "myctx", "sample", "argument"},
 			expectedValue: "myctx",
-			expectedArgs:  []string{"dummy", "argument"},
+			expectedArgs:  []string{"sample", "argument"},
 		},
 		{
-			args:          []string{"dummy", "--context", "myctx", "argument"},
+			args:          []string{"sample", "--context", "myctx", "argument"},
 			expectedValue: "myctx",
-			expectedArgs:  []string{"dummy", "argument"},
+			expectedArgs:  []string{"sample", "argument"},
 		},
 		{
-			args:          []string{"dummy", "argument", "--context", "myctx"},
+			args:          []string{"sample", "argument", "--context", "myctx"},
 			expectedValue: "myctx",
-			expectedArgs:  []string{"dummy", "argument"},
+			expectedArgs:  []string{"sample", "argument"},
 		},
 		{
-			args:          []string{"--context=myctx", "dummy", "argument"},
+			args:          []string{"--context=myctx", "sample", "argument"},
 			expectedValue: "myctx",
-			expectedArgs:  []string{"dummy", "argument"},
+			expectedArgs:  []string{"sample", "argument"},
 		},
 		{
-			args:          []string{"dummy", "--context=myctx", "argument"},
+			args:          []string{"sample", "--context=myctx", "argument"},
 			expectedValue: "myctx",
-			expectedArgs:  []string{"dummy", "argument"},
+			expectedArgs:  []string{"sample", "argument"},
 		},
 		{
-			args:          []string{"dummy", "argument", "--context=myctx"},
+			args:          []string{"sample", "argument", "--context=myctx"},
 			expectedValue: "myctx",
-			expectedArgs:  []string{"dummy", "argument"},
+			expectedArgs:  []string{"sample", "argument"},
 		},
 	}
 


### PR DESCRIPTION
fixes #438 so that we default to using the kaniko `--context` of the folder containing the `Dockerfile` unless folks specify `--context` in the kaniko args